### PR TITLE
Proposal for confirming voting cpc reps from At Large & Growth nominees

### DIFF
--- a/proposals/stage-0/INITIAL_CPC_VOTING_REPS.md
+++ b/proposals/stage-0/INITIAL_CPC_VOTING_REPS.md
@@ -1,0 +1,39 @@
+# Initial CPC Voting Representative Selection
+>  Stage 0
+
+## Champion
+
+Jory Burson (@jorydotcom)
+
+## Description
+
+In issue #152 we have identified 10 representatives from the Impact projects who will be confirmed as voting CPC Representatives. We have also identified 5 nominees for 2 available positions per the [CPC Charter](https://github.com/openjs-foundation/bootstrap/blob/master/CPC-CHARTER.md) from the At Large and Growth Stage projects. Per the charter, the CPC must hold an election. We do not yet have an election system in place.
+
+This document proposes that we accept all 5 of the initial nominees as voting CPC representatives for an interim period of 6 months, by consensus of the Bootstrap team. During this period, the CPC should take the selection and adoption of an election system as a priority. At the end of the term, there shall be a new call for nominees and an election for the 2 available positions as outlined in the charter.
+
+## Required Resources
+
+none
+
+## Who would be responsible?
+
+Bootstrap Committee / CPC
+
+## How would success be measured?
+
+* nominees are all confirmed
+* election tool/process is selected and implemented
+* new election from nominees is held within 6 months
+
+## Why this proposal is important
+
+I believe this proposal is a 'simplest next step' to booting the functionality of the new CPC with voting members. It welcomes and acknowledges all those who have volunteered their time to participate in an official capacity and invites them to the decision-making table. 
+
+## Unresolved Question
+
+Is 6 months the right amount of time?
+Resolving the > 25% from one company issue
+
+## What is necessary to complete this proposal
+
+Consensus of the CPC/Bootstrap committee. Documenting the requirements & timeline.


### PR DESCRIPTION
This PR captures the verbal proposal we have discussed in our meeting session about confirming the nominees from issue #152 - it proposes that we accept all 5 nominees as voting representatives for a period of time, allowing us to select an implement an election system, and that we hold an election for the 2 available positions after the period has ended.