### PR TITLE
doc: update readme for CPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,12 @@ Each Impact Project may appoint 2 representatives to the CPC as outlined in the 
 
 #### Growth & At Large Project Representatives
 
-According to the [CPC Charter](https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#voting-members), each of the Growth and At Large Projects may nominate a candidate to fill one of two voting seats on the CPC which represent this group of projects as a whole. Currently, the six individuals listed below were nominated during the bootstrap process and [the bootstrap committee decided](https://github.com/openjs-foundation/cross-project-council/issues/152) that all nominees would be given a voting seat until a process for nomination and election of these representatives was formalized.
+According to the [CPC Charter](https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#voting-members), each of the Growth and At Large Projects may nominate a candidate to fill one of two voting seats on the CPC which represent this group of projects as a whole. Currently, the five individuals listed below were nominated during the bootstrap process and [the bootstrap committee decided](https://github.com/openjs-foundation/cross-project-council/issues/152) that all nominees would be given a voting seat until a process for nomination and election of these representatives was formalized.
 
 - **Architect**: Kris Borchers (@kborchers)
 - **messageformat**: Eemeli Aro (@eemeli)
 - **Mocha**: Christopher Hiller (@boneskull)
 - **Node-RED**: Nick O'Leary (@knolleary)
-- **WebdriverIO**: Christian Bromann (@bromann)
 - **webhint**: Antón Molleda (@molant)
 
 <!-- ### Regular Members -->

--- a/README.md
+++ b/README.md
@@ -1,43 +1,93 @@
-# Foundation Bootstrap Team
+# The OpenJS Foundation Cross Project Council
 
-This is the operating repository for the Foundation Bootstrap Team.
+The OpenJS Foundation Cross Project Council (CPC) is the technical governing body of the OpenJS Foundation. It is described in the [CPC Charter](./CPC-CHARTER.md)
 
-The Foundation Bootstrap Team is the temporary body tasked with managing community recommendations for the transition of the merged Node.js and JS Foundation to a permanent governance model.
+## CPC Scope
 
-The files in this repository are living documents and will never represent finished governance. Once we reach consensus on governance, this repository will be archived and the documents will be moved to their new home in a Foundation specific Github org.
+The CPC's primary role is to foster an environment of collaboration. That environment extends within and between OpenJS Foundation Projects. It also extends between the Projects and the larger community.
 
-Until such a time that this group has consensus on a new governance model, and the Foundation has any legal requirements satisfied, all projects, programs, and committees will continue to operate unchanged.
+The CPC exercises autonomy in managing its responsibilities and seeks agreement from the OpenJS Foundation Board on any change to the scope of those responsibilities.
 
-Upon enactment of this new governance model, this working body will be disbanded.
+### OpenJS Fondation Projects
 
-> Note: If there is to be an extended Bootstrap transition committee to, for example, provide oversight in the organization's first year, those criteria must be defined as a new program in the proposed governance model. There is no extension of **this** specific group's life-cycle.
+#### Impact Project
 
+* Appium
+* Dojo
+* jQuery
+* Node.js
+* webpack
 
-## Definitions
-Throughout this repository we may use assorted acronyms and jargon to describe many complex concepts. This language is subject to change as we iterate on proposals. To help onboard and level-set, we will maintain an active list of commonly used language here. If you see domain specific language used in this repository that is not represented here, please add it!
+#### Growth Projects
 
-| Vocabulary | Definition |
-|---|---|
-| Bootstrap | This repo, team, and process. |
-| Contributor | You, and anyone that interacts with this repo. |
-| Ignition | The decision to move forward with the new governance structure. |
-| TLCs | The Top Level Councils of the project – Currently proposed as CPC and C3 (defined below) |
-| CPC | A new proposed Top Level Committee – The "Cross Project Council |
-| C3 | A new proposed Top Level Committee – The "Cross Community Council |
-| CNCF | The Cloud Native Computing Foundation (Prior Art) |
-| COC | Code of Conduct |
-| MVF | Minimum Viable Foundation – The bare minimum governance documentation to operate a function joint foundation |
-| Proposal | The staged proposal feedback and iteration process followed in the `/proposals` directory. |
+* architect
+* Intern
+* Mocha
+* Node-Red
+* WebdriverIO
+* webhint
 
-## Deliverables
-The deliverables from this body will be:
+#### At-Large Projects
 
-  - [ ] A recommendations document to help inform the new Foundation's by-laws.
-  - [ ] A recommendations document to help inform the TLCs' charters.
-  - [ ] A collection of fully drafted governance documents required for "Ignition". This is "Minimum Viable Foundation" (MVF).
-  - [ ] A collection of program, initiative, and governance recommendation documents not required for MVF. After Ignition these will be passed to the appropriate bodies (CPC, C3, etc.) to execute.
+* ESLint
+* Esprima
+* Express
+* Grunt
+* HospitalRun
+* Interledger.js
+* JerryScript
+* Libuv
+* Lodash
+* Marko
+* messageformat
+* Moment
+* PEP
+* QUnit
 
+#### Emeritus Projects
 
-## Making proposals
+* Chassis
+* jQuery Mobile
+* jQuery UI
+* RequireJS
+* Sizzle
+
+## CPC Members
+
+### Voting Members
+
+#### Impact Project Representatives
+
+Each Impact Project may appoint 2 representatives to the CPC as outlined in the [CPC Charter](https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#voting-members)
+
+- **Appium**: Dan Graham (@dpgraham) & Jonah Stiennon(@Jonahss)
+- **Dojo**: Matt Gadd (@matt-gadd) & Dylan Schiemann (@dylans)
+- **jQuery**: Dave Methvin (@dmethvin) & Timmy Willison (@timmywil)
+- **Node.js**: Matteo Collina (@mcollina ) & Joe Sepi (@joesepi)
+- **webpack**: Sean Larkin (@TheLarkInn) & Even Stensberg (@evenstensberg)
+
+#### Growth & At Large Project Representatives
+
+According to the [CPC Charter](https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#voting-members), each of the Growth and At Large Projects may nominate a candidate to fill one of two voting seats on the CPC which represent this group of projects as a whole. Currently, the six individuals listed below were nominated during the bootstrap process and [the bootstrap committee decided](https://github.com/openjs-foundation/cross-project-council/issues/152) that all nominees would be given a voting seat until a process for nomination and election of these representatives was formalized.
+
+- **Architect**: Kris Borchers (@kborchers)
+- **messageformat**: Eemeli Aro (@eemeli)
+- **Mocha**: Christopher Hiller (@boneskull)
+- **Node-RED**: Nick O'Leary (@knolleary)
+- **WebdriverIO**: Christian Bromann (@bromann)
+- **webhint**: Antón Molleda (@molant)
+
+<!-- ### Regular Members -->
+
+<!-- ### Observers -->
+
+## Policy Change Proposal Process
+
+The OpenJS CPC is chartered to oversee the technical governance of all OpenJS Projects and Working Groups under the OpenJS Foundation. The CPC establishes the default governance, conduct, and licensing policies for all Projects. Projects have broad powers of self-governance.
 
 Anyone may submit an idea for a policy or program following the [staging process](STAGING_PROCESS.md).
+
+The pull request can be labeled cross-project-council-agenda to request that it be put on the agenda for the next CPC meeting.
+
+The OpenJS Foundation Board of Directors retains certain rights (especially legal considerations). If the CPC endorses a proposal, they will escalate to the OpenJS Foundation Board of Directors when required to do so.
+

--- a/artifacts/BOOTSTRAP_README.md
+++ b/artifacts/BOOTSTRAP_README.md
@@ -1,0 +1,45 @@
+# Foundation Bootstrap Team
+
+> The following is an archived copy of the readme from this repo while it was part of the bootstrap process
+
+This is the operating repository for the Foundation Bootstrap Team.
+
+The Foundation Bootstrap Team is the temporary body tasked with managing community recommendations for the transition of the merged Node.js and JS Foundation to a permanent governance model.
+
+The files in this repository are living documents and will never represent finished governance. Once we reach consensus on governance, this repository will be archived and the documents will be moved to their new home in a Foundation specific Github org.
+
+Until such a time that this group has consensus on a new governance model, and the Foundation has any legal requirements satisfied, all projects, programs, and committees will continue to operate unchanged.
+
+Upon enactment of this new governance model, this working body will be disbanded.
+
+> Note: If there is to be an extended Bootstrap transition committee to, for example, provide oversight in the organization's first year, those criteria must be defined as a new program in the proposed governance model. There is no extension of **this** specific group's life-cycle.
+
+
+## Definitions
+Throughout this repository we may use assorted acronyms and jargon to describe many complex concepts. This language is subject to change as we iterate on proposals. To help onboard and level-set, we will maintain an active list of commonly used language here. If you see domain specific language used in this repository that is not represented here, please add it!
+
+| Vocabulary | Definition |
+|---|---|
+| Bootstrap | This repo, team, and process. |
+| Contributor | You, and anyone that interacts with this repo. |
+| Ignition | The decision to move forward with the new governance structure. |
+| TLCs | The Top Level Councils of the project – Currently proposed as CPC and C3 (defined below) |
+| CPC | A new proposed Top Level Committee – The "Cross Project Council |
+| C3 | A new proposed Top Level Committee – The "Cross Community Council |
+| CNCF | The Cloud Native Computing Foundation (Prior Art) |
+| COC | Code of Conduct |
+| MVF | Minimum Viable Foundation – The bare minimum governance documentation to operate a function joint foundation |
+| Proposal | The staged proposal feedback and iteration process followed in the `/proposals` directory. |
+
+## Deliverables
+The deliverables from this body will be:
+
+  - [ ] A recommendations document to help inform the new Foundation's by-laws.
+  - [ ] A recommendations document to help inform the TLCs' charters.
+  - [ ] A collection of fully drafted governance documents required for "Ignition". This is "Minimum Viable Foundation" (MVF).
+  - [ ] A collection of program, initiative, and governance recommendation documents not required for MVF. After Ignition these will be passed to the appropriate bodies (CPC, C3, etc.) to execute.
+
+
+## Making proposals
+
+Anyone may submit an idea for a policy or program following the [staging process](STAGING_PROCESS.md).


### PR DESCRIPTION
Currently still specific to Bootstrap.

Old README is archived in artifacts

Refs: https://github.com/nodejs/TSC/blob/master/README.md