### PR TITLE
governance: add guests to charter

### DIFF
--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -44,7 +44,7 @@ direction of the policies set by the Board.
 
 ## Section 4. Establishment of the CPC.
 
-The CPC is an inclusive group with f types of participants:
+The CPC is an inclusive group with four types of participants:
 
 * Observers
 * Regular members

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -44,12 +44,17 @@ direction of the policies set by the Board.
 
 ## Section 4. Establishment of the CPC.
 
-The CPC is an inclusive group with three types of participants:
+The CPC is an inclusive group with f types of participants:
 
 * Observers
 * Regular members
 * Voting members
+* Invited Guests
 
+### Invited Guests
+
+Guests are invited to attend either individual meetings or a set of meetings for a set
+period of time. They are not able to participate in the consensus seeking process.
 
 ### Observers
 
@@ -182,8 +187,9 @@ ensuring:
       from the mentorship program, Project issues and conflicts, opportunities
       for collaboration between Projects, opportunities for the Foundation in the
       greater JavaScript community, etc.
-  
-     
+
+### Guests
+
 ## Section 6. Non-Responsibilities of the CPC
 
 OpenJS Foundation Projects are self-governing entities. All policies and procedures for interacting with, contributing to and making decisions within a Project are defined, implemented, and documented by that Project’s maintainers and community during the mentorship process. Specific technical decisions within a Project will be the responsibility of the Project and establishment and implementation of the decision making process will be done within the guidelines as defined by CPC charter. Those Project decisions and responsibilities include but are not limited to:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -21,6 +21,7 @@ The following groups automatically have membership and can request to be added t
 * OpenJS Foundation Regular Members
 * OpenJS Foundation Board of Directors
 * OpenJS Foundation Project Maintainers
+* OpenJS Foundation Invited Guests
 
 ## Team Meetings
 


### PR DESCRIPTION
Hey All,

This came up in putting together the work for the project progression process... how do we want to handle invited guests who do not participate in consensus seeking.

I also noticed that we never identify in the charter or governance what qualifies something as an observer. I have similarly not documented how to invite a guest. It seems like perhaps we want a bit more policy around this, but I'm unsure if it belongs in the charter or in the GOVERNANCE.md

We might want to refactor this quite a bit