### PR TITLE
doc: add https for esprima website

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The CPC exercises autonomy in managing its responsibilities and seeks agreement 
 #### At-Large Projects
 
 * [ESLint](https://eslint.org/)
-* [Esprima](http://esprima.org/)
+* [Esprima](https://esprima.org/)
 * [Express](https://expressjs.com/)
 * [Grunt](https://gruntjs.com/)
 * [HospitalRun](https://hospitalrun.io/)


### PR DESCRIPTION
https link wasn't added in #218 as their ssl certificate was invalid
it was followed up and fixed in https://github.com/jquery/esprima/issues/1975