### PR TITLE
doc: add https for jerryscript website

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The CPC exercises autonomy in managing its responsibilities and seeks agreement 
 * [Grunt](https://gruntjs.com/)
 * [HospitalRun](https://hospitalrun.io/)
 * [Interledger.js](https://interledgerjs.org/)
-* [JerryScript](http://jerryscript.net/)
+* [JerryScript](https://jerryscript.net/)
 * [Libuv](https://libuv.org/)
 * [Lodash](https://lodash.com/)
 * [Marko](https://markojs.com/)


### PR DESCRIPTION
https link wasn't added in #218 as their ssl certificate was invalid
it was followed up and fixed in https://github.com/jerryscript-project/jerryscript/issues/2924