### PR TITLE
proposal: OpenJS Travel fund

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,17 @@ According to the [CPC Charter](https://github.com/openjs-foundation/cross-projec
 - Myles Borins (@MylesBorins)
 - Sendil Kumar (@sendilkumarn)
 
-<!-- ### Observers -->
+### Observers
+
+Anyone can be an Observer.
+Observers are free to attend meetings and participate in the work of the CPC as well 
+as the consensus seeking process. Observers are encouraged to participate and 
+volunteer but should refrain from disrupting or blocking progress. Observers 
+are expected to participate in a positive and collaborative manner as well as 
+following the [code of conduct](https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md) 
+and [member expectations](https://github.com/openjs-foundation/cross-project-council/blob/master/MEMBER_EXPECTATIONS.md) 
+like other CPC participants. If an Observer fails to meet these expectations they can 
+be excluded from future CPC meetings based on a standard CPC motion.
 
 ## Policy Change Proposal Process
 

--- a/proposals/stage-0/TRAVEL_FUND/README.md
+++ b/proposals/stage-0/TRAVEL_FUND/README.md
@@ -1,0 +1,56 @@
+# OpenJS Travel Fund
+>  Stage 0
+
+Tracked by https://github.com/openjs-foundation/cross-project-council/issues/172
+
+## Champion
+
+Jonah Stiennon @jonahss
+
+## Description
+
+The Node.js organizations that existed prior to the formation of the OpenJS foundation oversaw a monetary fund for the purpose of member and affiliate travel to, and lodging at, events related to the foundation's mission. This proposal proposes moving the management responsibilities of this fund to the Cross Project Council (CPC), and making the funds available to all members of this broader organization. Since all projects have voting representation on the CPC, the beneficiaries of the fund will jointly manage it, and the previous owners of the fund will still vote on its use.
+
+We shall review the process in this proposal, but the intent is to leave the mechanics of the fund unchanged, simply moving from the purview of the Node.js project into the domain of the OpenJS Foundation, overseen by the CPC. This operation can be viewed as a refactor which moves the travel fund up one level in the organizational tree.
+
+## Difference from the current process
+
+The existing process requires approval from two members of the Node.js TSC and two members of the Node.js Community Committee.
+The new process will requiree approval from four members of the CPC.
+
+The treasurer will be a member of the CPC rather than the Node.js TSC or Community Committee.
+
+## Practical Specifics
+
+- Move relevant files from nodejs/admin to openjs-foundation/cross-project-council such as:
+  - https://github.com/nodejs/admin/blob/master/MEMBER_TRAVEL_FUND.md
+  - https://github.com/nodejs/admin/tree/master/TravelFunds
+  - https://github.com/nodejs/admin/blob/master/travel-visas.md
+  - https://github.com/nodejs/admin/blob/master/expense-report-template.xls
+  - https://github.com/nodejs/admin/blob/master/reimbursement_process.pdf
+- Modify these files to account for OpenJS rather than Node.js organizations
+- Remove mentions from nodejs/admin README, add links to CPC README
+- Expensify account needs to be migrated to OpenJS if it is not already
+- Create new email address to take the place of travelapprovals@nodejs.org
+
+## Required Resources
+
+Permissions to the services and financial accounts involved. I believe @brianwarner should already have access, in which case there is nothing more to be done.
+
+## How would success be measured?
+
+Success will be achieved if non-Node.js members use the travel fund to attend a Foundation-related event.
+
+## Why this proposal is important
+
+Organizationally, the Node.js project is at the same level as the other impact projects in the Foundation, and so the travel fund should benefit all projects equally in opportunity. Plus, the sponsorships which pay for the fund sponsor the entire Foundation, not just the Node.js project.
+
+## Unresolved Questions
+
+- Which group is in charge of the actual budget?
+- Does this require Board approval?
+
+## What is necessary to complete this proposal
+
+- Definition and wording of the travel fund mechanics
+- Transfer of the current travel fund and tools/accounts to the CPC

--- a/proposals/stage-0/TRAVEL_FUND/README.md
+++ b/proposals/stage-0/TRAVEL_FUND/README.md
@@ -53,4 +53,5 @@ Organizationally, the Node.js project is at the same level as the other impact p
 
 ## What is necessary to complete this proposal
 
+- Approval and buy-in from Node.js TSC and CommComm. 
 - Definition and wording of the travel fund mechanics, mostly moving files and updating references.

--- a/proposals/stage-0/TRAVEL_FUND/README.md
+++ b/proposals/stage-0/TRAVEL_FUND/README.md
@@ -46,7 +46,7 @@ Organizationally, the Node.js project is at the same level as the other impact p
 
 ## Unresolved Questions
 
-None at this time.
+- Who is the current treasurer of the fund?
 
 ## What is necessary to complete this proposal
 

--- a/proposals/stage-0/TRAVEL_FUND/README.md
+++ b/proposals/stage-0/TRAVEL_FUND/README.md
@@ -30,16 +30,15 @@ The treasurer will be a member of the CPC rather than the Node.js TSC or Communi
   - https://github.com/nodejs/admin/blob/master/reimbursement_process.pdf
 - Modify these files to account for OpenJS rather than Node.js organizations
 - Remove mentions from nodejs/admin README, add links to CPC README
-- Expensify account needs to be migrated to OpenJS if it is not already
-- Create new email address to take the place of travelapprovals@nodejs.org
 
 ## Required Resources
 
-Permissions to the services and financial accounts involved. I believe @brianwarner should already have access, in which case there is nothing more to be done.
+@brianwarner reports that everything can stay the same for the tools and accounts involved.
+No other resources required.
 
 ## How would success be measured?
 
-Success will be achieved if non-Node.js members use the travel fund to attend a Foundation-related event.
+Success will be achieved if Node.js and non-Node.js members use the travel fund to attend a Foundation-related event, and nobody notices the difference.
 
 ## Why this proposal is important
 
@@ -47,8 +46,7 @@ Organizationally, the Node.js project is at the same level as the other impact p
 
 ## Unresolved Questions
 
-- Which group is in charge of the actual budget?
-- Does this require Board approval?
+None at this time.
 
 ## What is necessary to complete this proposal
 

--- a/proposals/stage-0/TRAVEL_FUND/README.md
+++ b/proposals/stage-0/TRAVEL_FUND/README.md
@@ -53,5 +53,6 @@ Organizationally, the Node.js project is at the same level as the other impact p
 
 ## What is necessary to complete this proposal
 
-- Approval and buy-in from Node.js TSC and CommComm. 
+- Approval and buy-in from Node.js TSC and CommComm.
+- OpenJS board approval
 - Definition and wording of the travel fund mechanics, mostly moving files and updating references.

--- a/proposals/stage-0/TRAVEL_FUND/README.md
+++ b/proposals/stage-0/TRAVEL_FUND/README.md
@@ -50,5 +50,4 @@ Organizationally, the Node.js project is at the same level as the other impact p
 
 ## What is necessary to complete this proposal
 
-- Definition and wording of the travel fund mechanics
-- Transfer of the current travel fund and tools/accounts to the CPC
+- Definition and wording of the travel fund mechanics, mostly moving files and updating references.

--- a/proposals/stage-0/TRAVEL_FUND/README.md
+++ b/proposals/stage-0/TRAVEL_FUND/README.md
@@ -20,7 +20,7 @@ The current fund is used mostly for attending collaborator summits, and we do no
 The existing process requires approval from two members of the Node.js TSC and two members of the Node.js Community Committee.
 The new process will require approval from four members of the CPC.
 
-The treasurer will be a member of the CPC rather than the Node.js TSC or Community Committee.
+The role of fund "treasurer" will be removed, as it has been found to be redundant and is not currently filled (see https://github.com/openjs-foundation/cross-project-council/pull/268#issuecomment-513888283).
 
 ## Practical Specifics
 
@@ -32,6 +32,7 @@ The treasurer will be a member of the CPC rather than the Node.js TSC or Communi
   - https://github.com/nodejs/admin/blob/master/reimbursement_process.pdf
 - Modify these files to account for OpenJS rather than Node.js organizations
 - Remove mentions from nodejs/admin README, add links to CPC README
+- Remove the role of treasurer
 
 ## Required Resources
 

--- a/proposals/stage-0/TRAVEL_FUND/README.md
+++ b/proposals/stage-0/TRAVEL_FUND/README.md
@@ -13,6 +13,8 @@ The Node.js organizations that existed prior to the formation of the OpenJS foun
 
 We shall review the process in this proposal, but the intent is to leave the mechanics of the fund unchanged, simply moving from the purview of the Node.js project into the domain of the OpenJS Foundation, overseen by the CPC. This operation can be viewed as a refactor which moves the travel fund up one level in the organizational tree.
 
+The current fund is used mostly for attending collaborator summits, and we do not expect this to change.
+
 ## Difference from the current process
 
 The existing process requires approval from two members of the Node.js TSC and two members of the Node.js Community Committee.

--- a/proposals/stage-0/TRAVEL_FUND/README.md
+++ b/proposals/stage-0/TRAVEL_FUND/README.md
@@ -45,7 +45,7 @@ Success will be achieved if Node.js and non-Node.js members use the travel fund 
 
 ## Why this proposal is important
 
-Organizationally, the Node.js project is at the same level as the other impact projects in the Foundation, and so the travel fund should benefit all projects equally in opportunity. Plus, the sponsorships which pay for the fund sponsor the entire Foundation, not just the Node.js project.
+The Node.js project has demonstrated the value of providing a travel fund which allows project members to get together at collaborator summits and to represent/advocate for the project at other events. It is important to expand the travel fund (both resource and usage) so that other projects can benefit as well.
 
 ## Unresolved Questions
 

--- a/proposals/stage-0/TRAVEL_FUND/README.md
+++ b/proposals/stage-0/TRAVEL_FUND/README.md
@@ -17,7 +17,7 @@ The current fund is used mostly for attending collaborator summits, and we do no
 
 ## Difference from the current process
 
-The existing process requires approval from two members of the Node.js TSC and two members of the Node.js Community Committee.
+The existing process requires approval from two members of the [Node.js TSC](https://github.com/nodejs/TSC) and two members of the [Node.js Community Committee](https://github.com/nodejs/community-committee).
 The new process will require approval from four members of the CPC.
 
 The role of fund "treasurer" will be removed, as it has been found to be redundant and is not currently filled (see https://github.com/openjs-foundation/cross-project-council/pull/268#issuecomment-513888283).


### PR DESCRIPTION
>The Node.js organizations that existed prior to the formation of the OpenJS foundation oversaw a monetary fund for the purpose of member and affiliate travel to, and lodging at, events related to the foundation's mission. This proposal proposes moving the management responsibilities of this fund to the Cross Project Council (CPC), and making the funds available to all members of this broader organization. Since all projects have voting representation on the CPC, the beneficiaries of the fund will jointly manage it, and the previous owners of the fund will still vote on its use.
>
>The intent is to leave the mechanics of the fund unchanged, simply moving from the purview of the Node.js project into the domain of the OpenJS Foundation, overseen by the CPC. This operation can be viewed as a refactor which moves the travel fund up one level in the organizational tree.


Who is the current treasurer? I'd like to @mention them in this review.

Is there anybody else I should specifically solicit for feedback, who may not be subscribed to this repo?

Addresses https://github.com/openjs-foundation/cross-project-council/issues/172