### PR TITLE
doc: swapping refs to TAC with CPC

### DIFF
--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -293,13 +293,13 @@ from the OpenJS Foundation board.
 ## Section 11. Definitions
 
 **Project**: a technical collaboration effort that is organized through the
-project mentorship process and approved by the TAC.
+project mentorship process and approved by the CPC.
 
 **Contributors**: contribute code or other artifacts, but do not have the right
 to commit to the code base. Contributors work with the Project's Collaborators
 to have code committed to the code base. A Contributor may be promoted to a
 Collaborator by the Project's Maintainers. Contributors should rarely be
-encumbered by the TAC or Board.
+encumbered by the CPC or Board.
 
 **Collaborator**: a Contributor within a Project that has made significant and
 valuable contributions and has been given commit-access to that Project


### PR DESCRIPTION
Unfortunately, this wasn't caught earlier and is a change to the Charter, which has a higher bar to meet before merging.

From Governance doc
https://github.com/openjs-foundation/cross-project-council/blob/master/GOVERNANCE.md#merging-prs-into-this-repository
>Pull requests that change the charter of the CPC must meet the following conditions in additon to the ones listed for changing CPC governance:
>
>The text of the PR must be approved by a simple majority of the voting members.
>The text of the PR must be approved by the board.