### PR TITLE
adds a draft charter template

### DIFF
--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -45,6 +45,8 @@ ex. [K8s SIG Architecture Charter](https://github.com/kubernetes/community/blob/
 _directions: describe how the project intersects with the Cross Project_
 _Council._ 
 
+ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-2-evolution-of-openjs-foundation-governance)
+
 ### 2.1 Other Formal Project Relationships (optional)
 
 _directions: describe any additional affiliations or groups that liaise with_

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -30,6 +30,8 @@ _or other projects which are included with the work but may not be readily_
 _apparent. This may help differentiate the project from other solutions in the_
 _space._
 
+ex. [K8s SIG Architecture Charter](https://github.com/kubernetes/community/blob/master/sig-architecture/charter.md#in-scope)
+
 ### 1.2: Out-of-Scope (optional)
 
 _directions: list or bullet out areas that may be seen to be related but are_

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -88,3 +88,5 @@ ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.
 
 _directions: include any definitions that may help clarify terms or ideas found_
 _in this charter document._
+
+ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-9-definitions)

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -70,6 +70,9 @@ _directions: use this section to describe any other specific tasks the_
 _${PROJECT TSC} may be responsible for regarding process or project_
 _operations and management._
 
+ex. [K8s SIG Architecture Charter](https://github.com/kubernetes/community/blob/master/sig-architecture/charter.md#roles-and-organization-management)
+ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-5-nodejs-project-operations)
+
 ### Section 4.2: Decision-making, Voting, and/or Elections (optional)
 
 _directions: describe any provisions the project makes for decision-making_

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -28,7 +28,8 @@ ex. [K8s SIG Architecture Charter](https://github.com/kubernetes/community/blob/
 _directions: list or bullet out problem spaces, use cases, repositories_
 _or other projects which are included with the work but may not be readily_
 _apparent. This may help differentiate the project from other solutions in the_
-_space._
+_space. If you are not using this section, please indicate your intent with the_
+_phrase, 'Section Intentionally Left Blank'._
 
 ex. [K8s SIG Architecture Charter](https://github.com/kubernetes/community/blob/master/sig-architecture/charter.md#in-scope)
 
@@ -37,6 +38,8 @@ ex. [K8s SIG Architecture Charter](https://github.com/kubernetes/community/blob/
 _directions: list or bullet out areas that may be seen to be related but are_
 _not included in the scope of this project. This may help clarify the kind of_
 _features, contributions, issues or problems the project is looking for._
+_If you are not using this section, please indicate your intent with the_
+_phrase, 'Section Intentionally Left Blank'._
 
 ex. [K8s SIG Architecture Charter](https://github.com/kubernetes/community/blob/master/sig-architecture/charter.md#out-of-scope)
 
@@ -51,6 +54,8 @@ ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.
 
 _directions: describe any additional affiliations or groups that liaise with_
 _the project in a formal way (such as a W3C Community Group, for example)._ 
+_If you are not using this section, please indicate your intent with the_
+_phrase, 'Section Intentionally Left Blank'._
 
 ## Section 3: Establishment of the ${PROJECT TSC}.
 
@@ -72,7 +77,8 @@ ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.
 
 _directions: use this section to describe any other specific tasks the_
 _${PROJECT TSC} may be responsible for regarding process or project_
-_operations and management._
+_operations and management. If you are not using this section, please indicate_
+_your intent with the phrase, 'Section Intentionally Left Blank'._
 
 ex. [K8s SIG Architecture Charter](https://github.com/kubernetes/community/blob/master/sig-architecture/charter.md#roles-and-organization-management)
 ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-5-nodejs-project-operations)
@@ -81,6 +87,8 @@ ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.
 
 _directions: describe any provisions the project makes for decision-making_
 _or include the information by reference your governance.md document._
+_If you are not using this section, please indicate your intent with the_
+_phrase, 'Section Intentionally Left Blank'._
 
 ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-6-elections)
 
@@ -90,12 +98,15 @@ _directions: describe other roles within the project, such as chairperson,_
 _tech lead, collaborator, contributor, maintainer, etc. and any responsibilities or_
 _rights such role confers. You can also include this information by_
 _reference to your governance.md document._
+_If you are not using this section, please indicate your intent with the_
+_phrase, 'Section Intentionally Left Blank'._
 
 ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-8-project-roles)
 
 ### Section 5: Definitions (optional)
 
 _directions: include any definitions that may help clarify terms or ideas found_
-_in this charter document._
+_in this charter document. If you are not using this section, please indicate_ 
+_your intent with the phrase, 'Section Intentionally Left Blank'._
 
 ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-9-definitions)

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -80,6 +80,8 @@ ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.
 _directions: describe any provisions the project makes for decision-making_
 _or include the information by reference your governance.md document._
 
+ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-6-elections)
+
 ### Section 4.3: Other Project Roles (optional)
 
 _directions: describe other roles within the project, such as chairperson,_

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -1,0 +1,77 @@
+# ${PROJECT} Charter
+
+_note: the purpose of a project charter is to provide a brief introduction_
+_to the project from a technical, community, or business perspective. The_ 
+_document also connects a project's community leadership and governance with the_
+_OpenJS Foundation's governance._
+
+
+## Section 0: Guiding Principles (optional)
+
+_directions: provide a concise, high-level statement about_
+_the project's long-term principles, values, or mission._
+
+## Section 1: Scope
+
+_directions: Include a 3-4 sentence summary of what the project does,_
+_and/or what problems it solves. Imagine trying to explain your work_
+_to a colleague who is familiar with related technical concepts but unfamiliar_
+_with the project. You may also want to describe the project's value to community_
+_and/or business stakeholders._
+
+### 1.1: In-scope (optional)
+
+_directions: list or bullet out problem spaces, use cases, repositories_
+_or other projects which are included with the work but may not be readily_
+_apparent. This may help differentiate the project from other solutions in the_
+_space._
+
+### 1.2: Out-of-Scope (optional)
+
+_directions: list or bullet out areas that may be seen to be related but are_
+_not included in the scope of this project. This may help clarify the kind of_
+_features, contributions, issues or problems the project is looking for._
+
+## Section 2: Relationship with OpenJS Foundation CPC.
+
+_directions: describe how the project intersects with the Cross Project_
+_Council._ 
+
+### 2.1 Other Formal Project Relationships (optional)
+
+_directions: describe any additional affiliations or groups that liaise with_
+_the project in a formal way (such as a W3C Community Group, for example)._ 
+
+## Section 3: Establishment of the ${PROJECT TSC}.
+
+_directions: describe the structure of the group responsible for managing_
+_the project and its respective organization and repositories. If there are_
+_specific rules for membership or participation in the group, list them here or_
+_by reference to a governance.md document._
+
+## Section 4: Roles & Responsibilities 
+
+_directions: describe the roles and responsibilities of the ${PROJECT TSC}._
+
+### Section 4.1 Project Operations & Management (optional)
+
+_directions: use this section to describe any other specific tasks the_
+_${PROJECT TSC} may be responsible for regarding process or project_
+_operations and management._
+
+### Section 4.2: Decision-making, Voting, and/or Elections (optional)
+
+_directions: describe any provisions the project makes for decision-making_
+_or include the information by reference your governance.md document._
+
+### Section 4.3: Other Project Roles (optional)
+
+_directions: describe other roles within the project, such as chairperson,_
+_tech lead, collaborator, contributor, maintainer, etc. and any responsibilities or_
+_rights such role confers. You can also include this information by_
+_reference to your governance.md document._
+
+### Section 5: Definitions (optional)
+
+_directions: include any definitions that may help clarify terms or ideas found_
+_in this charter document._

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -61,6 +61,9 @@ ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.
 
 _directions: describe the roles and responsibilities of the ${PROJECT TSC}._
 
+ex. [K8s SIG Architecture Charter](https://github.com/kubernetes/community/blob/master/sig-architecture/charter.md#roles-and-organization-management)
+ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-4-responsibilities-of-the-tsc)
+
 ### Section 4.1 Project Operations & Management (optional)
 
 _directions: use this section to describe any other specific tasks the_

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -11,6 +11,8 @@ _OpenJS Foundation's governance._
 _directions: provide a concise, high-level statement about_
 _the project's long-term principles, values, or mission._
 
+ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-1-guiding-principle)
+
 ## Section 1: Scope
 
 _directions: Include a 3-4 sentence summary of what the project does,_

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -38,6 +38,8 @@ _directions: list or bullet out areas that may be seen to be related but are_
 _not included in the scope of this project. This may help clarify the kind of_
 _features, contributions, issues or problems the project is looking for._
 
+ex. [K8s SIG Architecture Charter](https://github.com/kubernetes/community/blob/master/sig-architecture/charter.md#out-of-scope)
+
 ## Section 2: Relationship with OpenJS Foundation CPC.
 
 _directions: describe how the project intersects with the Cross Project_

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -57,7 +57,7 @@ _the project in a formal way (such as a W3C Community Group, for example)._
 _If you are not using this section, please indicate your intent with the_
 _phrase, 'Section Intentionally Left Blank'._
 
-## Section 3: Establishment of the ${PROJECT TSC}.
+## Section 3: ${PROJECT TSC} Governing Body
 
 _directions: describe the structure of the group responsible for managing_
 _the project and its respective organization and repositories. If there are_

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -82,6 +82,8 @@ _tech lead, collaborator, contributor, maintainer, etc. and any responsibilities
 _rights such role confers. You can also include this information by_
 _reference to your governance.md document._
 
+ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-8-project-roles)
+
 ### Section 5: Definitions (optional)
 
 _directions: include any definitions that may help clarify terms or ideas found_

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -68,7 +68,7 @@ ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.
 
 ## Section 4: Roles & Responsibilities 
 
-_directions: describe the roles and responsibilities of the ${PROJECT TSC}._
+_directions: describe the roles and responsibilities of the ${PROJECT} Governing Body._
 
 ex. [K8s SIG Architecture Charter](https://github.com/kubernetes/community/blob/master/sig-architecture/charter.md#roles-and-organization-management)
 ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-4-responsibilities-of-the-tsc)
@@ -76,7 +76,7 @@ ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.
 ### Section 4.1 Project Operations & Management (optional)
 
 _directions: use this section to describe any other specific tasks the_
-_${PROJECT TSC} may be responsible for regarding process or project_
+_${PROJECT} Governing Body may be responsible for regarding process or project_
 _operations and management. If you are not using this section, please indicate_
 _your intent with the phrase, 'Section Intentionally Left Blank'._
 
@@ -103,7 +103,7 @@ _phrase, 'Section Intentionally Left Blank'._
 
 ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-8-project-roles)
 
-### Section 5: Definitions (optional)
+## Section 5: Definitions (optional)
 
 _directions: include any definitions that may help clarify terms or ideas found_
 _in this charter document. If you are not using this section, please indicate_ 

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -55,6 +55,8 @@ _the project and its respective organization and repositories. If there are_
 _specific rules for membership or participation in the group, list them here or_
 _by reference to a governance.md document._
 
+ex. [Node.js TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-3-establishment-of-the-tsc)
+
 ## Section 4: Roles & Responsibilities 
 
 _directions: describe the roles and responsibilities of the ${PROJECT TSC}._

--- a/PROJECT_CHARTER_TEMPLATE.md
+++ b/PROJECT_CHARTER_TEMPLATE.md
@@ -21,6 +21,8 @@ _to a colleague who is familiar with related technical concepts but unfamiliar_
 _with the project. You may also want to describe the project's value to community_
 _and/or business stakeholders._
 
+ex. [K8s SIG Architecture Charter](https://github.com/kubernetes/community/blob/master/sig-architecture/charter.md#scope)
+
 ### 1.1: In-scope (optional)
 
 _directions: list or bullet out problem spaces, use cases, repositories_


### PR DESCRIPTION
This is a draft charter template - a need per #207.  Wasn't sure if this should go through the proposal process since it's a document we need to unblock other issues - if that's the case LMK and I will update the PR to put this is a proposal folder. 

I used the Node TSC charter and the Kubernetes SIG Charter template as a basis. The trick is to make the charter document work for projects of different sizes, as there will be some information that will be applicable to large projects but not to the small ones. Hence, some of the sections I marked 'optional' but please do share your thoughts and comments on this!