### PR TITLE
Update Interledger website

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The CPC exercises autonomy in managing its responsibilities and seeks agreement 
 * [Express](https://expressjs.com/)
 * [Grunt](https://gruntjs.com/)
 * [HospitalRun](https://hospitalrun.io/)
-* [Interledger.js](https://interledgerjs.org/)
+* [Interledger.js](https://interledger.org/)
 * [JerryScript](https://jerryscript.net/)
 * [Libuv](https://libuv.org/)
 * [Lodash](https://lodash.com/)


### PR DESCRIPTION
Brings the Interledger link in-line with other links – a website, rather than the GitHub org (removed link redirects to GitHub org)