### PR TITLE
doc: rename acceptance criteria to graduation criteria

### DIFF
--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -153,7 +153,7 @@ It is expected that incubating project will make an active effort to work throug
 
 **Acceptance Criteria**
 
-1. 2/3 vote from the CPC to accept project (during silent period).
+1. consensus within private mailing list to move into incubation process
 
 #### Graduation Criteria
 

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -153,9 +153,9 @@ It is expected that incubating project will make an active effort to work throug
 
 **Acceptance Criteria**
 
-1. 2/3 vote from the CPC to accept project during silent phase
+1. 2/3 vote from the CPC to accept project (during silent period).
 
-#### Exit Criteria
+#### Graduation Criteria
 
 1. Completion of the on-boarding checklist
 1. 2/3 vote from the CPC to accept project

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -153,7 +153,7 @@ It is expected that incubating project will make an active effort to work throug
 
 **Acceptance Criteria**
 
-1. 2/3 cote from the CPC to accept project during silent phase
+1. 2/3 vote from the CPC to accept project during silent phase
 
 #### Exit Criteria
 

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -158,7 +158,7 @@ It is expected that incubating project will make an active effort to work throug
 #### Exit Criteria
 
 1. Completion of the on-boarding checklist
- 1. 2/3 vote from the CPC to accept project
+1. 2/3 vote from the CPC to accept project
 1. Completion of the entrance criteria for desired stage
 
 ## IV. Annual Review Process

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -158,7 +158,7 @@ It is expected that incubating project will make an active effort to work throug
 #### Exit Criteria
 
 1. Completion of the on-boarding checklist
-1. 2/3 cote from the CPC to accept project
+ 1. 2/3 vote from the CPC to accept project
 1. Completion of the entrance criteria for desired stage
 
 ## IV. Annual Review Process

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -153,6 +153,10 @@ It is expected that incubating project will make an active effort to work throug
 
 **Acceptance Criteria**
 
+1. 2/3 cote from the CPC to accept project during silent phase
+
+#### Exit Criteria
+
 1. Completion of the on-boarding checklist
 1. 2/3 cote from the CPC to accept project
 1. Completion of the entrance criteria for desired stage


### PR DESCRIPTION
The acceptance criteria listed in the Incubation phase are actually exit criteria.

Hence adding an "Exit Criteria" subsection and moving them there.