### PR TITLE
doc: remove duplicate checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-onboarding-checklist-template.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding-checklist-template.md
@@ -11,22 +11,4 @@ assignees: ''
 
 **Stage: ${Project Stage}
 
-- [ ] Adopt the [OpenJS Foundation Code of Conduct](https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md) - update the project's Code of Conduct file
-- [ ] Update project CoC reporting methods to include OpenJS Foundation escalation path
-- [ ] Transfer official domains to OpenJS Foundation
-- [ ] Identify and document other core project infrastructure, including hosting, CDNs, CI/CD tooling, etc. If the project anticipates anticipate additional needs, document that as well. 
-- [ ] If choosing to use a Contributor License Agreement (CLA) or Developer Certificate of Origin (DCO), make selection and implement appropriate tool
-- [ ] Add or Update GOVERNANCE.md document (required for Impact stage); Growth & At Large projects can choose a simpler approach to documenting project leadership and decision-making such as including the info in the README or Contributing.md file. 
-- [ ] Confirm required files in place (CODE_OF_CONDUCT.md, LICENSE.md, GOVERNANCE.md (impact only))
-- [ ] Project Charter is published on website or github
-- [ ] Update legal copyright notice on project website and github
-- [ ] Add OpenJS Foundation logo to project website
-- [ ] Add Project logo to OpenJS Foundation website; update PROJECTS.md file
-- [ ] Transfer IP and logomark to the OpenJS Foundation
-- [ ] List any crowdfunding platforms (such as Open Collective) used by the project. If project is using crowdfunding platforms, add appropriate disclaimer to platforms.
-- [ ] Identify individuals from the project to join the CPC as Regular or Voting (Impact only) members
-- [ ] Document contacts from the project and the foundation for:
-  * marketing & social media 
-  * infrastructure & technical leadership
-  * legal/governance help
-  * OpenJS communications channels (slack, project mailing lists)
+Please copy paste the checklist from the [New Project Application](../../NEW_PROJECT_APPLICATION.md#onboarding-checklist)

--- a/.github/ISSUE_TEMPLATE/project-onboarding-checklist-template.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding-checklist-template.md
@@ -9,7 +9,7 @@ assignees: ''
 
 ## Project Onboarding Checklist - ${Project Name}
 
-<!--Copied from ../../NEW_PROJECT_APPLICATION.md on 2019-08-23 -->
+<!--Copied from ../../PROJECT_PROGRESSION.md on 2019-08-23 -->
 
 **Stage: ${Project Stage}
 

--- a/.github/ISSUE_TEMPLATE/project-onboarding-checklist-template.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding-checklist-template.md
@@ -9,6 +9,25 @@ assignees: ''
 
 ## Project Onboarding Checklist - ${Project Name}
 
+<!--Copied from ../../NEW_PROJECT_APPLICATION.md on 2019-08-23 -->
+
 **Stage: ${Project Stage}
 
-Please copy paste the checklist from the [New Project Application](../../NEW_PROJECT_APPLICATION.md#onboarding-checklist)
+- [ ] Adopt the OpenJS Foundation Code of Conduct
+- [ ] Update project CoC reporting methods to include OpenJS Foundation escalation path
+- [ ] Transfer official domains to OpenJS Foundation
+- [ ] Identify and document other core project infrastructure
+- [ ] If choosing to use a Contributor License Agreement (CLA) or Developer Certificate of Origin (DCO), make selection and implement appropriate tool
+- [ ] Add or Update Governance.md document (required for Impact stage)
+- [ ] Confirm required files in place (CODE_OF_CONDUCT.md, LICENSE.md)
+- [ ] Project Charter is published on website or github
+- [ ] Update legal copyright notice on project website and github
+- [ ] Add OpenJS Foundation logo to project website
+- [ ] Add Project logo to OpenJS Foundation website; update PROJECTS.md file
+- [ ] Transfer logomark to the OpenJS Foundation
+- [ ] If project is using crowdfunding platforms, add disclaimer to platforms
+- [ ] Identify individuals from the project to join the CPC
+- [ ] Document project and foundation contacts for:
+  * marketing & social media
+  * infrastructure
+  * legal/governance help

--- a/NEW_PROJECT_APPLICATION.md
+++ b/NEW_PROJECT_APPLICATION.md
@@ -59,29 +59,6 @@ Does your project currently receive funds? Who do they come from and what are th
 
 What needs will your project have from the foundation? Feel free to provide a list.
 
-## Onboarding Checklist
-
-This is an informational checklist to help projects onboard into the OpenJS Foundation - tasks we will complete together after your project has been accepted into the incubation process. If you have any questions or need help, the OpenJS Foundation CPC is available to assist.
-
-- [ ] Adopt the OpenJS Foundation Code of Conduct
-- [ ] Update project CoC reporting methods to include OpenJS Foundation escalation path
-- [ ] Transfer official domains to OpenJS Foundation
-- [ ] Identify and document other core project infrastructure
-- [ ] If choosing to use a Contributor License Agreement (CLA) or Developer Certificate of Origin (DCO), make selection and implement appropriate tool
-- [ ] Add or Update Governance.md document (required for Impact stage)
-- [ ] Confirm required files in place (CODE_OF_CONDUCT.md, LICENSE.md)
-- [ ] Project Charter is published on website or github
-- [ ] Update legal copyright notice on project website and github
-- [ ] Add OpenJS Foundation logo to project website
-- [ ] Add Project logo to OpenJS Foundation website; update PROJECTS.md file
-- [ ] Transfer logomark to the OpenJS Foundation
-- [ ] If project is using crowdfunding platforms, add disclaimer to platforms
-- [ ] Identify individuals from the project to join the CPC
-- [ ] Document project and foundation contacts for:
-  * marketing & social media
-  * infrastructure
-  * legal/governance help
-
 ## Questions?
 
 What questions do you have? What questions might arise during your application?

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -21,8 +21,31 @@ New projects should express interest to join the OpenJS Foundation via an email 
 1. Initial email sent to new-projects@lists.openjsf.org with filled out [Project Application Template](./NEW_PROJECT_APPLICATION.md).
 1. Silent period. Internal only discussion.
 1. Initial acceptance as [Incubating][] Project.
-1. Project goes through process of adhering to on-boarding checklist from [Project Application Template](./NEW_PROJECT_APPLICATION.md).
+1. Project goes through process of adhering to [on-boarding checklist](#onboarding-checklist).
 1. Project presents to CPC for final acceptance via 2/3 supermajority vote and appropriate initial stage is determined.
+
+## Onboarding Checklist
+
+This is an informational checklist to help projects onboard into the OpenJS Foundation - tasks we will complete together after your project has been accepted into the incubation process. If you have any questions or need help, the OpenJS Foundation CPC is available to assist.
+
+- [ ] Adopt the OpenJS Foundation Code of Conduct
+- [ ] Update project CoC reporting methods to include OpenJS Foundation escalation path
+- [ ] Transfer official domains to OpenJS Foundation
+- [ ] Identify and document other core project infrastructure
+- [ ] If choosing to use a Contributor License Agreement (CLA) or Developer Certificate of Origin (DCO), make selection and implement appropriate tool
+- [ ] Add or Update Governance.md document (required for Impact stage)
+- [ ] Confirm required files in place (CODE_OF_CONDUCT.md, LICENSE.md)
+- [ ] Project Charter is published on website or github
+- [ ] Update legal copyright notice on project website and github
+- [ ] Add OpenJS Foundation logo to project website
+- [ ] Add Project logo to OpenJS Foundation website; update PROJECTS.md file
+- [ ] Transfer logomark to the OpenJS Foundation
+- [ ] If project is using crowdfunding platforms, add disclaimer to platforms
+- [ ] Identify individuals from the project to join the CPC
+- [ ] Document project and foundation contacts for:
+  * marketing & social media
+  * infrastructure
+  * legal/governance help
 
 ## III. Stages - Definitions & Expectations
 

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -26,6 +26,8 @@ New projects should express interest to join the OpenJS Foundation via an email 
 
 ## Onboarding Checklist
 
+<!--If this checklist is updated please ensure `.github/ISSUE_TEMPLATE/project-onboarding-checklist-template.md` is updated as well -->
+
 This is an informational checklist to help projects onboard into the OpenJS Foundation - tasks we will complete together after your project has been accepted into the incubation process. If you have any questions or need help, the OpenJS Foundation CPC is available to assist.
 
 - [ ] Adopt the OpenJS Foundation Code of Conduct


### PR DESCRIPTION
This removes the duplicated checklist in the issue template and
instead links to the checklist in the new project application

Fixes: #288