### PR TITLE
Add project exit criteria

### DIFF
--- a/proposals/stage-0/PROJECT_EXIT_CRITERIA/README.md
+++ b/proposals/stage-0/PROJECT_EXIT_CRITERIA/README.md
@@ -1,0 +1,44 @@
+# Project Exit Criteria
+>  Stage 0
+
+## Champion
+
+[Sendil Kumar N](https://github.com/sendilkumarn)
+
+## Description
+
+This proposal codifies the process for projects should do before exiting the foundation. It includes a checklist to be used by the projects and the foundation when the project is exiting the OpenJS Foundation.
+
+## Who would be responsible?
+
+The Project, The Foundation
+
+## Why this proposal is important?
+
+A project can leave the foundation because of the following reason:
+
+* Project decided to leave the foundation
+
+> There are many other reasons. We will focus on the above reason to codify the basic criteria then expand the reasons.
+
+It is important to codify this process that will ensure transparent and efficient way of removing a project from the foundation and informing everybody about this.
+
+## What is necessary to complete this proposal?
+
+* Board buy in and approval to leave the foundation
+* Receive a two-thirds supermajority vote of the CPC to remove the project.
+
+The project should: 
+* transfer its assets to another non-profit [a (c)6 or (c)3 in the US].
+* remove all the references to foundation.
+* return all the infra, assets provided by the foundation.
+
+The foundation should: 
+* remove the project references.
+* revoke access to any assets provided by the foundation.
+
+Other questions:
+* What should we if the project is in any investigation (like Code of Conduct breach)?
+* How we should educate the users about this removal? 
+* Do we have to remove the project completely from all of our other projects?
+   - For example, Project A wants to leave and Project B has Project A as one of its dependency. Do we have to ask Project B to look for an alternative?

--- a/proposals/stage-0/PROJECT_EXIT_CRITERIA/README.md
+++ b/proposals/stage-0/PROJECT_EXIT_CRITERIA/README.md
@@ -38,5 +38,5 @@ The foundation should:
 * revoke access to any assets provided by the foundation.
 
 Other questions:
-* What should we if the project is in any investigation (like Code of Conduct breach)?
+* What should we do if the project is in any investigation (like Code of Conduct breach)?
 * How we should educate the users about this removal?

--- a/proposals/stage-0/PROJECT_EXIT_CRITERIA/README.md
+++ b/proposals/stage-0/PROJECT_EXIT_CRITERIA/README.md
@@ -39,6 +39,4 @@ The foundation should:
 
 Other questions:
 * What should we if the project is in any investigation (like Code of Conduct breach)?
-* How we should educate the users about this removal? 
-* Do we have to remove the project completely from all of our other projects?
-   - For example, Project A wants to leave and Project B has Project A as one of its dependency. Do we have to ask Project B to look for an alternative?
+* How we should educate the users about this removal?


### PR DESCRIPTION
addresses #96 

We will first focus on a minimal use case that _a project decided to leave the foundation_.

> Please note: There are many other use cases. We will first codify the basic criteria then expand the usecases.

Thanks @jorydotcom for the help and idea 👍 