### PR TITLE
doc: building out our issue templates for better clarity

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-project-onboarding-checklist-template.md
+++ b/.github/ISSUE_TEMPLATE/00-project-onboarding-checklist-template.md
@@ -1,5 +1,5 @@
 ---
-name: Project Onboarding Checklist Template
+name: "\U0001F680 Project Onboarding Checklist Template"
 about: For capturing action items related to onboarding new / incubating projects
 title: "[ONBOARDING] ${Project Name}"
 labels: onboarding
@@ -31,3 +31,4 @@ assignees: ''
   * marketing & social media
   * infrastructure
   * legal/governance help
+

--- a/.github/ISSUE_TEMPLATE/99-custom-issue.md
+++ b/.github/ISSUE_TEMPLATE/99-custom-issue.md
@@ -1,0 +1,11 @@
+---
+name: "\U0001F47E All other issues"
+about: If your issue doesn't fit the other templates, please open a custom issue
+---
+
+<!--
+
+Thank you so much for getting involved with the work and efforts of the OpenJS Foundation's Cross Project Council. Please describe your issue in adequate details below. This comment may be removed.
+
+-->
+


### PR DESCRIPTION
It has been discussed in a meeting or two that there should be more than one issue template. Currently, if you are opening an issue other than a project onboarding issue, the generic/custom issue option isn't obvious. We've implemented something similar in Node in a few areas (see below). I've created these same issue templates in a personal repository so you can see what they look like in action:
- https://github.com/sometotal/leastbestbeast.com/issues/new/choose

For more issue template implementations, see the following:
- https://github.com/nodejs/node/issues/new/choose
- https://github.com/nodejs/user-feedback/issues/new/choose