### PR TITLE
adds infra menu PR for discussion per issue #333 & CPC conversation

### DIFF
--- a/INFRASTRUCTURE_MENU.md
+++ b/INFRASTRUCTURE_MENU.md
@@ -1,6 +1,6 @@
 # OpenJS Foundation Project Infrastructure Services
 
-The OpenJS Foundation provides works with a number of services to provide critical infrastructure services to hosted projects.  We expect projects to be respectful of these services, to abide by their terms of use, and to use the for the good of the project and the OpenJS Foundation.
+The OpenJS Foundation provides a number of services to support critical infrastructure for hosted projects.  We expect projects to be respectful of these services, to abide by their terms of use, and to be put into use for the good of the project and the OpenJS Foundation.
 
 ## Billing for services and mitigating the bus factor
 **For all project services, please add an OpenJS Foundation account at an owner or highest-level of permission access.**  This helps ensure continuity by reducing the bus factor on the project, and ensures you are never locked out.  It is also **required** in order for the OpenJS Foundation to pay service fees on behalf of your project.  Access to the OpenJS Foundation administrator/owner account will never be shared with others, and will only be granted to operations, IT, and finance staff at the Linux Foundation.
@@ -19,7 +19,7 @@ The OpenJS Foundation will register and manage each project’s primary domain, 
 The OpenJS Foundation can either manage your DNS for you, or delegate to one of your own nameservers.  This is often required if you use a CDN (see below).
 
 ## SSL Certificates
-The OpenJS Foundation will purchase 2-year wildcard SSL certs for each projects’ managed domains as needed.
+The OpenJS Foundation will purchase 2-year wildcard SSL certs for each project's managed domains as needed.
 
 ## Source Control
 By default all OpenJS Foundation projects have open source repositories in their own GitHub Organizations.  The OpenJS Foundation admin account must be added as administrator for each repository.  Two-factor authentication must be required for everyone in the organization.
@@ -51,7 +51,7 @@ Projects are welcome to create channels on the OpenJS Foundation Slack (https://
 ## Zoom
 Projects may request that standing meetings be added to the OpenJS Foundation calendar.  The OpenJS Foundation currently has two Zoom Pro meeting accounts, and one Zoom Webinar account which is capable of livestreaming.  Please be mindful of conflicts with other projects by requesting your meeting be scheduled on the shared calendar via email to operations@openjsf.org.   
 
-All OpenJS Foundation Zoom accounts have can host up to 300 participants, and meetings can be recorded as an .mp4 for posting to a project’s YouTube channel.
+All OpenJS Foundation Zoom accounts can host up to 300 participants, and meetings can be recorded as an .mp4 for posting to a project’s YouTube channel.
 
 Impact and Growth projects with extensive meeting requests can request a dedicated Zoom Pro account.  Projects may also request a Webinar license for livestreaming, but please be aware it is a significant expense and is subject to budget approval.
 

--- a/INFRASTRUCTURE_MENU.md
+++ b/INFRASTRUCTURE_MENU.md
@@ -1,0 +1,61 @@
+# OpenJS Foundation Project Infrastructure Services
+
+The OpenJS Foundation provides works with a number of services to provide critical infrastructure services to hosted projects.  We expect projects to be respectful of these services, to abide by their terms of use, and to use the for the good of the project and the OpenJS Foundation.
+
+## Billing for services and mitigating the bus factor
+**For all project services, please add an OpenJS Foundation account at an owner or highest-level of permission access.**  This helps ensure continuity by reducing the bus factor on the project, and ensures you are never locked out.  It is also **required** in order for the OpenJS Foundation to pay service fees on behalf of your project.  Access to the OpenJS Foundation administrator/owner account will never be shared with others, and will only be granted to operations, IT, and finance staff at the Linux Foundation.
+
+If you don’t know the name of the OpenJS Foundation account for a service, please contact operations@openjsf.org.
+
+## Websites
+Digital Ocean offers free droplets to OpenJS Foundation projects.  Projects are solely responsible for the content and design of their websites.
+
+## Servers
+Additional servers needed to run scripts, bots, or other project applications may also be deployed on Digital Ocean.  These resources are generously provided by Digital Ocean for free, so please be respectful of the arrangement and do not deploy overly intensive workloads such as CI/CD without discussion with the Foundation.  Additional servers can be procured on behalf of the project pending request and budget approval.
+
+## DNS
+The OpenJS Foundation will register and manage each project’s primary domain, and the .org, .dev, .net, and .com variants (as available).  The project’s primary domain must be transferred to the Foundation if the project desires the foundation to take financial and management responsibility for the domain.  Management of additional domain names may be requested, subject to budget approval.
+
+The OpenJS Foundation can either manage your DNS for you, or delegate to one of your own nameservers.  This is often required if you use a CDN (see below).
+
+## SSL Certificates
+The OpenJS Foundation will purchase 2-year wildcard SSL certs for each projects’ managed domains as needed.
+
+## Source Control
+By default all OpenJS Foundation projects have open source repositories in their own GitHub Organizations.  The OpenJS Foundation admin account must be added as administrator for each repository.  Two-factor authentication must be required for everyone in the organization.
+
+## Build (CI/CD)
+Projects which require CI/CD should attempt to use solutions which are free to open source projects, such as https://travis-ci.org/.  Non-free options may be requested, subject to budget approval.
+
+## Distribution
+Projects with a technical need for a CDN should attempt to use no-cost services from sites like https://www.jsdelivr.com/, https://www.keycdn.com/open-source-cdn, or others.  Non-free options may be requested, subject to budget approval.
+
+## Website Monitoring
+The OpenJS Foundation can provide website downtime and performance monitoring through StatusCake or Pingdom.
+
+## Open Source Dependency Monitoring (FOSSA)
+
+## Credential Storage
+The OpenJS Foundation can provide credential storage and sharing through LastPass Enterprise.  Because the credentials are shared through a LastPass Enterprise account, each user only needs a free account to receive them.  Managed credentials may include:
+
+* Usernames / Passwords
+* Secret keys
+* Notes or documentation
+
+## Email
+The OpenJS Foundation uses Groups.io for mailing lists on the openjsf.org domain.  All projects are welcome to request their own lists on the @lists.openjsf.org subdomain.
+
+## Slack
+Projects are welcome to create channels on the OpenJS Foundation Slack (https://openjs-foundation.slack.com), or set up their own free Slack workspace.
+
+## Zoom
+Projects may request that standing meetings be added to the OpenJS Foundation calendar.  The OpenJS Foundation currently has two Zoom Pro meeting accounts, and one Zoom Webinar account which is capable of livestreaming.  Please be mindful of conflicts with other projects by requesting your meeting be scheduled on the shared calendar via email to operations@openjsf.org.   
+
+All OpenJS Foundation Zoom accounts have can host up to 300 participants, and meetings can be recorded as an .mp4 for posting to a project’s YouTube channel.
+
+Impact and Growth projects with extensive meeting requests can request a dedicated Zoom Pro account.  Projects may also request a Webinar license for livestreaming, but please be aware it is a significant expense and is subject to budget approval.
+
+## Other services
+We recognize that some projects may have needs not addressed by the above list.  For no-cost services, please let us know what you’re using at operations@openjsf.org so that we can add the service to our inventory.  For services with a fee, please reach out to operations@openjsf.org to coordinate a proposal and budget request.
+
+OpenJS Foundation Member companies can sponsor additional per-project services subject to limitations set by the board. 


### PR DESCRIPTION
This PR would add the foundation's "infrastructure menu of services" to the CPC repo. I was not 100% clear where it should ultimately live in the repo, but this PR is meant first to gather feedback and questions on the menu. 