### PR TITLE
adds missing links for bylaws and mission/vision statements

### DIFF
--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -35,7 +35,7 @@ and direction of the policies as described in the CPC Policy document and
 approved by the Board.
 
 The Board sets the overall CPC policy through [Foundation mission and vision
-statements][] as well as within the [Foundation bylaws][]. The policy describes
+statements][https://openjsf.org/about/] as well as within the [Foundation bylaws][https://bylaws.openjsf.org]. The policy describes
 the overarching scope of the OpenJS Foundation initiatives , technical vision,
 and direction. The Board uses the CPC as a delegate body for governing
 high-level technical policy and procedures while remaining within the scope and

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -34,8 +34,7 @@ individual project scope and direction while they remain within the scope
 and direction of the policies as described in the CPC Policy document and
 approved by the Board.
 
-The Board sets the overall CPC policy through [Foundation mission and vision
-statements][https://openjsf.org/about/] as well as within the [Foundation bylaws][https://bylaws.openjsf.org]. The policy describes
+The Board sets the overall CPC policy through [Foundation mission and vision statements][] as well as within the [Foundation bylaws][]. The policy describes
 the overarching scope of the OpenJS Foundation initiatives , technical vision,
 and direction. The Board uses the CPC as a delegate body for governing
 high-level technical policy and procedures while remaining within the scope and
@@ -309,8 +308,8 @@ repository.
 in an official decision making role as defined in the Project's governance
 policies.
 
-[Foundation mission and vision statements]:  xx
-[Foundation bylaws]:  x
+[Foundation mission and vision statements]:  https://openjsf.org/about/
+[Foundation bylaws]:  https://bylaws.openjsf.org
 [Voting]:  #section-10.-voting
 [Elections]: #section-7.-elections
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making


### PR DESCRIPTION
Issues #230 and #322 note that the links in our CPC charter to the foundations Bylaws and mission/vision statements do not work. 

We point new applicants to these documents for drafting project submissions. This PR points applicants to what I believe are the best available documents to support their drafts.