### PR TITLE
Add a copy of the Contributor Covenant CoC text

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,37 +1,116 @@
 # Code of Conduct
 
-The OpenJS Foundation and its member projects use the Contributor
-Covenant v1.4.1 as its Code of Conduct. Refer to the following
-for the full text:
+The OpenJS Foundation and its member projects use [Contributor Covenant v1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct) as their code of conduct. The full text is included [below](#contributor-covenant-code-of-conduct) in English, and translations are available from the Contributor Covenant organisation:
 
-* [english](https://www.contributor-covenant.org/version/1/4/code-of-conduct)
-* [translations](https://www.contributor-covenant.org/translations)
+- [contributor-covenant.org/translations](https://www.contributor-covenant.org/translations)
+- [github.com/ContributorCovenant](https://github.com/ContributorCovenant/contributor_covenant/tree/release/content/version/1/4)
 
-Refer to the section on reporting and escalation in this document for the specific emails that can be used to report and escalate issues.
+Refer to the sections on reporting and escalation in this document for the specific emails that can be used to report and escalate issues.
 
-# Reporting
+## Reporting
 
-## Project Spaces
+### Project Spaces
 
-For reporting issues in spaces related to a member project please use the email provided by the project for reporting. Projects handle CoC issues related to the spaces that they maintain.  Projects maintainers commit to:
+For reporting issues in spaces related to a member project please use the email provided by the project for reporting. Projects handle CoC issues related to the spaces that they maintain. Projects maintainers commit to:
 
-* maintain the confidentiality with regard to the reporter of an incident
-* to participate in the path for escalation as outlined in
+- maintain the confidentiality with regard to the reporter of an incident
+- to participate in the path for escalation as outlined in
   the section on Escalation when required.
 
-## Foundation Spaces
+### Foundation Spaces
+
 For reporting issues in spaces managed by the OpenJS Foundation, for example, repositories within the OpenJS organization, use the email `report@lists.openjsf.org`. The Cross Project Council (CPC) is responsible for managing these reports and commits to:
 
-* maintain the confidentiality with regard to the reporter of an incident
-* to participate in the path for escalation as outlined in
+- maintain the confidentiality with regard to the reporter of an incident
+- to participate in the path for escalation as outlined in
   the section on Escalation when required.
 
-# Escalation
+## Escalation
 
 The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to `coc-escalation@lists.openjsf.org`.
 
 For more information, refer to the full
 [Code of Conduct governance document](https://github.com/openjs-foundation/bootstrap/blob/master/proposals/stage-1/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
 
+---
 
+## Contributor Covenant Code of Conduct
 
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at the email addresses listed above in
+the [Reporting](#reporting) and [Escalation](#escalation) sections. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an
+incident. Further details of specific enforcement policies may be posted
+separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant], version 1.4,
+available at [contributor-covenant.org/version/1/4/code-of-conduct.html]
+
+For answers to common questions about this code of conduct, see
+[contributor-covenant.org/faq]
+
+[contributor covenant]: https://www.contributor-covenant.org
+[contributor-covenant.org/version/1/4/code-of-conduct.html]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+[contributor-covenant.org/faq]: https://www.contributor-covenant.org/faq


### PR DESCRIPTION
This adds a copy of the text of the Contributor Covenant, version 1.4, to our [CODE_OF_CONDUCT.md](../blob/master/CODE_OF_CONDUCT.md) document. The primary reason for this is to make it clear exactly what text we're using, as the language of the upstream "version 1.4.1" has had [a few modifications](https://github.com/ContributorCovenant/contributor_covenant/commits/release/content/version/1/4/code-of-conduct.md) made to it since its release in April 2017, without an accompanying version number change.

Regarding the text itself, I've taken the contents from the [current HEAD commit](https://github.com/ContributorCovenant/contributor_covenant/blob/0b42d477/content/version/1/4/code-of-conduct.md), and filled in the [INSERT EMAIL ADDRESS] bit in its Enforcement section with "the email addresses listed above in the Reporting and Escalation sections".

I've  also added a second github.com link for the translations, as with the recent release of the Contributor Covenant CoC version 2.0 it's likely that the links at https://www.contributor-covenant.org/translations will soon start to get updated to its translations.

~~**Edit:** See [comment below](#issuecomment-561281216) for refactored contents.~~

**Edit:** Never mind the previous edit. See [comment below](#issuecomment-565758404).