### PR TITLE
Update CoC from Contributor Covenant 1.4 to 2.0

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,9 @@
 # Code of Conduct
 
-The OpenJS Foundation and its member projects use [Contributor Covenant v1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct) as their code of conduct. The full text is included [below](#contributor-covenant-code-of-conduct) in English, and translations are available from the Contributor Covenant organisation:
+The OpenJS Foundation and its member projects use [Contributor Covenant v2.0](https://contributor-covenant.org/version/2/0/code_of_conduct) as their code of conduct. The full text is included [below](#contributor-covenant-code-of-conduct) in English, and translations are available from the Contributor Covenant organisation:
 
 - [contributor-covenant.org/translations](https://www.contributor-covenant.org/translations)
-- [github.com/ContributorCovenant](https://github.com/ContributorCovenant/contributor_covenant/tree/release/content/version/1/4)
+- [github.com/ContributorCovenant](https://github.com/ContributorCovenant/contributor_covenant/tree/release/content/version/2/0)
 
 Refer to the sections on reporting and escalation in this document for the specific emails that can be used to report and escalate issues.
 
@@ -34,83 +34,81 @@ For more information, refer to the full
 
 ---
 
-## Contributor Covenant Code of Conduct
+## Contributor Covenant Code of Conduct v2.0
 
 ### Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to make participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ### Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our community include:
 
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-- The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-- Trolling, insulting/derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-- Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
-### Our Responsibilities
+### Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ### Scope
 
-This Code of Conduct applies within all project spaces, and it also applies when
-an individual is representing the project or its community in public spaces.
-Examples of representing a project or community include using an official
-project e-mail address, posting via an official social media account, or acting
-as an appointed representative at an online or offline event. Representation of
-a project may be further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ### Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at the email addresses listed above in
-the [Reporting](#reporting) and [Escalation](#escalation) sections. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an
-incident. Further details of specific enforcement policies may be posted
-separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at the email addresses listed above in the [Reporting](#reporting) and [Escalation](#escalation) sections. All complaints will be reviewed and investigated promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+### Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+#### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+#### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+#### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+#### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the project community.
 
 ### Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant], version 1.4,
-available at [contributor-covenant.org/version/1/4/code-of-conduct.html]
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0, available at [contributor-covenant.org/version/2/0/code_of_conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct).
 
-For answers to common questions about this code of conduct, see
-[contributor-covenant.org/faq]
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
-[contributor covenant]: https://www.contributor-covenant.org
-[contributor-covenant.org/version/1/4/code-of-conduct.html]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
-[contributor-covenant.org/faq]: https://www.contributor-covenant.org/faq
+For answers to common questions about this code of conduct, see the FAQ at
+[contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are available at [contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).

--- a/proposals/stage-2/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md
+++ b/proposals/stage-2/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md
@@ -11,7 +11,7 @@ of the foundation.
 ## Code of Conduct
 
 The Foundation has adopted the
-[Contributor Covenant v1.4.1](https://www.contributor-covenant.org/version/1/4/code-of-conduct.md)
+[Contributor Covenant v2.0](https://www.contributor-covenant.org/version/2/0/code-of-conduct.md)
 as its code of conduct and it applies to all foundation activities and spaces. In
 addition, projects joining the foundation are required to adopt this code of conduct
 within 3 months of joining the foundation.

--- a/proposals/stage-2/CODE_OF_CONDUCT/HANDLING-REPORTS.md
+++ b/proposals/stage-2/CODE_OF_CONDUCT/HANDLING-REPORTS.md
@@ -17,8 +17,7 @@ reason for reporting to coc-escalation.
 
 ## Code of Conduct
 
-The OpenJS Foundation and its member projects use the Contributor Covenant v1.4.1 as its Code of Conduct. Refer to the [Code of Conduct](https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md) for the link to the full text of the CoC and the text for the reporting and esclation procedures. 
-
+The OpenJS Foundation and its member projects use the Contributor Covenant v2.0 as its Code of Conduct. Refer to the [Code of Conduct](https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md) for the full text of the CoC and the reporting and esclation procedures.
 
 ## Confidentiality and record-keeping
 Personal information is confidential. All reports should be recorded, together with the discussion of it. The following private repos will be used to record and discuss reports.


### PR DESCRIPTION
[Version 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct) of our upstream code of conduct, the [Contributor Covenant](https://www.contributor-covenant.org/), has been released. The project's [changelog](https://github.com/ContributorCovenant/contributor_covenant/blob/release/changelog) has not (yet) been updated, but by manual comparison the update appears to bring two major updates:
1. The initial pledge has an additional second part:  
    > We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
2. The "Enforcement Guidelines" section has been added, detailing actions that community leaders may take in response to infractions.

All other changes appear to be superficial.

This PR updates our references to "v1.4.1" of the Contributor Covenant to refer to its "v2.0" instead. The covenant claims to follow semver, but does not appear to actually publish enumerated patch releases separately; hence dropping the patch number.

This PR is related to #413, which makes our references to the covenant's version more explicit. If/once one of these is merged, the other will need to be amended.