### PR TITLE
fix markdown typos to make `npm run lint-md` run clean

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -71,7 +71,7 @@ As per the CPC charter, the term for all voting members is normally 1 year.
 
 From: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#voting-members
 > Voting members serve for a term of 1 year and must be re-nominated and ratified
-  by the Voting CPC members each year.
+> by the Voting CPC members each year.
 
 Due to the bootstrap process, the term for the first year will be
 shortened such that the initial term for all voting members ends March 31st, 2020.

--- a/proposals/stage-3/TRAVEL_FUND/README.md
+++ b/proposals/stage-3/TRAVEL_FUND/README.md
@@ -27,9 +27,9 @@ The suggestion to submit a "trip report" after travel has been removed. No trip 
 ## Who qualifies for using the Travel Fund?
 
 As the document currently states:
->* Candidates must be an active participant of one of the projects of the OpenJS Foundation.
->* Those requesting funds must indicate that they do not have funding available from another source, such as an employer or
-the event itself that might cover costs for presenters.
+> * Candidates must be an active participant of one of the projects of the OpenJS Foundation.
+> * Those requesting funds must indicate that they do not have funding available from another source, such as an employer or
+>   the event itself that might cover costs for presenters.
 
 This means, any project in the Foundation, no matter the level.
 For each project, any active participant is welcome to apply for funds. This would mean any contributor or someone active in the community. Their participation should be self-evident (github activity, etc), and if in doubt their project representative can be asked to confirm.


### PR DESCRIPTION
This should not affect the display or semantic content of either edited file.

Travis CI [warned](https://travis-ci.com/mikesamuel/cross-project-council/builds/141007449?utm_medium=notification&utm_source=email) on some lint-md errors in an unrelated PR.
