### PR TITLE
Add notes from CPC Meeting on 2020-01-14

### DIFF
--- a/meetings/2020-01-14.md
+++ b/meetings/2020-01-14.md
@@ -1,0 +1,101 @@
+# OpenJS Foundation Cross Project Council Meeting 2020-01-14
+
+## Links
+
+* **Recording**: https://www.youtube.com/watch?v=kwHp26-16bc
+* **GitHub Issue**: https://github.com/openjs-foundation/cross-project-council/issues/444
+
+## Present
+
+* Joe Sepi (@joesepi)
+* Michael Dawson (@mhdawson)
+* Myles Borins (@MylesBorins)
+* Rachel Romoff (@rromoff)
+* Anton Molleda (@molant)
+* Jory Burson (@jorydotcom)
+* Timmy Willison (@timmywil)
+* Jordan Harband (@LJHarb)
+* Christian Bromann (@christian-bromann)
+* Sendil Kumar (@sendilkumarn)
+* Ben Michel (@obensource)
+* Tierney Cyren (@bnb)
+* Mike Samuel (@mvsamuel)
+
+## Agenda
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+Jory:
+* Event CFP drops tomorrow
+* sponsorship prospectus
+* want to add public meetings to our cal, let us know
+* jquery ama, Feb. 5 10am, ask us anything
+
+Joe:
+* Standards meeting today @ 17:00 UTC
+* Collab Summit planning kickoff starts today immediately following this meeting (https://meet.google.com/isf-dbpw-nyz)
+
+
+
+### openjs-foundation/cross-project-council
+
+* Start a Code of Conduct Working Group [#432](https://github.com/openjs-foundation/cross-project-council/issues/432)
+  * open a call for participation - email to the projects list & coordinate initial meeting on issue
+  * need to make it clear that this group is not a moderation team, but rather a wg of people who will tackle/work through bigger process issues, concerns raised at Collab summit
+  * start a repo for this WG? We need volunteers.
+  * AI: small group to craft a clear problem statement about what the group will be working on, everyone to cast the net for participants  
+
+* Add Foundation-wide copyright guidance [#414](https://github.com/openjs-foundation/cross-project-council/pull/414)
+  * Don’t have Brian or Toby so skip for this week.
+
+* Kicking off an OpenJS Foundation project landscape [#411](https://github.com/openjs-foundation/cross-project-council/issues/411)
+  * ACTION: Brian to share proof of concept and then we can discuss further.
+
+* adds proposal for charter submission & review per #200 [#405](https://github.com/openjs-foundation/cross-project-council/pull/405)
+  * Jory, have done 2 in the approach outline in the doc
+  * Believe it is ready to land.
+  * Joe landed.
+
+* Add post-graduation checklist [#386](https://github.com/openjs-foundation/cross-project-council/pull/386)
+  * Needs more reviews
+
+* doc: move COC proposal to stage 3 [#379](https://github.com/openjs-foundation/cross-project-council/pull/379)	
+  * Blocked on [#432](https://github.com/openjs-foundation/cross-project-council/issues/432)
+
+* Clarify Travel Fund status & process [#377](https://github.com/openjs-foundation/cross-project-council/issues/377)
+  * Discussion recently in https://github.com/openjs-foundation/cross-project-council/issues/377
+  * Christian, could we ask each project to provide an estimate of what they might use
+  * Myles: if the board makes a statement that budget will be increased it would address Matteo's concerns
+  * Joe: we could also send out a survey
+  * deferred conversation until board meets
+
+
+* Responsible security disclosures [#326](https://github.com/openjs-foundation/cross-project-council/issues/326)
+  * Nothing to report this week. Work ongoing.
+
+* Post-Bootstrap work to be managed by CPC [#115](https://github.com/openjs-foundation/cross-project-council/issues/115)
+  * Add admin policy docs is in process
+
+### openjs-foundation/standards
+
+* OSI Affiliate Membership [#32](https://github.com/openjs-foundation/standards/issues/32)
+  * Would allow one of our members run for Affiliate board member.
+  * Discussion was positive, Myles to move it forward
+
+### openjs-foundation/project-onboarding
+
+* Communication channel between CPC and AMP infra WG [#31](https://github.com/openjs-foundation/project-onboarding/issues/31)
+  * Jory: was discussed at AMP infra working group meeting
+  * Jory: will confirm with Toby and document this week.
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: https://calendar.openjsf.org
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+
+

--- a/meetings/2020-01-14.md
+++ b/meetings/2020-01-14.md
@@ -20,6 +20,7 @@
 * Ben Michel (@obensource)
 * Tierney Cyren (@bnb)
 * Mike Samuel (@mvsamuel)
+* Abraham Jr. Agiri (@codeekage)
 
 ## Agenda
 


### PR DESCRIPTION
## Description
This PR publishes the meeting notes from the CPC's meeting on 2020-01-14.

Closes #444.

🎉