### PR TITLE
doc: add marketing committee rep to CoCP

### DIFF
--- a/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md
+++ b/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md
@@ -59,6 +59,7 @@ and code of conduct issues. The makeup of this team is as follows:
 * The Foundation Executive director
 * 1 member from the Board
 * 1 member from the CPC
+* 1 member of the OpenJS marketing committee
 * each top-level project may optionally provide 1 member
 * the non top-level projects may optionally provide 1 member
 * optionally 1 invited outside expert as agreed by the other CoCP members.


### PR DESCRIPTION
Add a representative from the marketing committee to the
CoCP. The CoC will be in place for conferences and
events run by the marketing committee and handling
of CoC reports from those events may be escalated to the
CoCP so they should have a represenative.