### PR TITLE
Amendment to the by laws to ensure a sign-off between Voting CPC members

### DIFF
--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -109,9 +109,11 @@ one-fourth of the Voting CPC membership to be affiliated with the same employer.
 Such a situation must be immediately remedied by the resignation or
 removal of one or more voting CPC members.
 
-If a Voting CPC member connected to an impact or non impact project is being
-replaced by someone from the same project, a sign off from the current active
-CPC member is required with an approval.
+If a voting CPC member steps down before the end of their one year term or they
+are removed from the CPC by a CPC motion they may be replaced using the same
+process by which they were elected. In this case the member will serve out the
+remainder of the term and must be re-confirmed at the end of the original one
+year term as if they had served for the full year.
 
 The public portion of the CPC discussions and meetings will be open to all
 observers and members.

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -109,6 +109,10 @@ one-fourth of the Voting CPC membership to be affiliated with the same employer.
 Such a situation must be immediately remedied by the resignation or
 removal of one or more voting CPC members.
 
+If a Voting CPC member connected to an impact or non impact project is being
+replaced by someone from the same project, a sign off from the current active
+CPC member is required with an approval of the new member.
+
 The public portion of the CPC discussions and meetings will be open to all
 observers and members.
 

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -111,7 +111,7 @@ removal of one or more voting CPC members.
 
 If a Voting CPC member connected to an impact or non impact project is being
 replaced by someone from the same project, a sign off from the current active
-CPC member is required with an approval of the new member.
+CPC member is required with an approval.
 
 The public portion of the CPC discussions and meetings will be open to all
 observers and members.


### PR DESCRIPTION
This patch adds a section to the by laws to ensure that Voting CPC members connected to an impact or non impact project are being signed off by the current active CPC member of that project.

See also discussions in https://github.com/openjs-foundation/cross-project-council/pull/483#issuecomment-595432313