### PR TITLE
Specify non-impact voting CPC member election timeframe

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -113,6 +113,8 @@ These members will be elected for a term of 1 year as follows:
 
 * Each voter will be able to vote for as many or as few candidates as they wish.
 
+* Voting will start a week after the nomination period ends, and be open for two weeks.
+
 * Those candidates who receive the greatest number of votes will be confirmed as
   the winners. In the case of a tie between 2 or more candidates, the winner will be
   chosen randomly unless:


### PR DESCRIPTION
As discussed in today's CPC meeting, the governance doc specifies the nomination period when electing non-impact projects' voting CPC members, but does not specify any other related timeframes.

This year, we're not going to start voting until after the next term starts tomorrow. It would be nice if we could lock down this timeframe to more specifics to help us make sure that the current situation is not repeated in future years.

This PR suggests an initial one week period for receiving nomination issues, and then a voting period of two weeks.