### PR TITLE
[WIP] Adds reporting emails 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,11 +11,18 @@ Refer to the sections on reporting and escalation in this document for the speci
 
 ### Project Spaces
 
-For reporting issues in spaces related to a member project please use the email provided by the project for reporting. Projects handle CoC issues related to the spaces that they maintain. Projects maintainers commit to:
+For reporting issues in spaces related to a member project, please use the email provided by the project for reporting which has been provided below. Projects handle CoC issues related to the spaces that they maintain. Projects maintainers commit to:
 
 - maintain the confidentiality with regard to the reporter of an incident
 - to participate in the path for escalation as outlined in
   the section on Escalation when required.
+
+#### Project Reporting Emails
+If a project has not provided a reporting path, you may use the escalation email.
+
+* AMP Project - `amphtml-coc@googlegroups.com`
+* Electron - `coc@electronjs.org`
+* Node.js - `report@nodejs.org`
 
 ### Foundation Spaces
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -18,7 +18,6 @@ For reporting issues in spaces related to a member project, please use the email
   the section on Escalation when required.
 
 #### Project Reporting Emails
-If a project has not provided a reporting path, you may use the escalation email.
 
 * AMP Project - `code-of-conduct@amp.dev`
 * Electron - `coc@electronjs.org`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,8 +20,34 @@ For reporting issues in spaces related to a member project, please use the email
 #### Project Reporting Emails
 
 * AMP Project - `code-of-conduct@amp.dev`
+* Appium - [email maintainers]
+* Architect - 
+* Dojo - [reporting form](https://docs.google.com/forms/d/1ZiCUv3FsarWetoQ8J5QnCdIrHLj0xMmwNSLCyBkio7c/viewform?edit_requested=true)
 * Electron - `coc@electronjs.org`
+* ESLint - 
+* Esprima - 
+* Express.js - `express-coc@lists.openjsf.org`
+* Fastify - `hello@matteocollina.com` or `tommydelved@gmail.com`
+* Grunt - 
+* HospitalRun - `hello@hospitalrun.io`
+* Interledger.js - 
+* Intern - 
+* JerryScript - 
+* jQuery - 
+* libuv - 
+* LoDash - 
+* messageformat - 
+* Marko - 
+* Mocha - `report@lists.openjsf.org`
+* Moment.js - 
 * Node.js - `report@nodejs.org`
+* Node-RED - `team@nodered.org`
+* nvm - 
+* Pep - 
+* QUnit - 
+* Webdriver.io - [contact TSC reps](https://github.com/webdriverio/webdriverio/blob/master/AUTHORS.md)
+* Webhint - `support@webhint.io`
+* webpack - [redirects here]
 
 ### Foundation Spaces
 
@@ -34,6 +60,7 @@ For reporting issues in spaces managed by the OpenJS Foundation, for example, re
 ## Escalation
 
 The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to `coc-escalation@lists.openjsf.org`.
+
 
 For more information, refer to the full
 [Code of Conduct governance document](https://github.com/openjs-foundation/bootstrap/blob/master/proposals/stage-2/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,7 +20,7 @@ For reporting issues in spaces related to a member project, please use the email
 #### Project Reporting Emails
 If a project has not provided a reporting path, you may use the escalation email.
 
-* AMP Project - `amphtml-coc@googlegroups.com`
+* AMP Project - `code-of-conduct@amp.dev`
 * Electron - `coc@electronjs.org`
 * Node.js - `report@nodejs.org`
 


### PR DESCRIPTION
This PR adds a list of the project-specific CoC reporting emails to our code of conduct, closing the loop for projects that wish to reference our code of conduct by providing a pointer to the URL https://code-of-conduct.openjsf.org. 