### PR TITLE
Updating requirements to become a regular member

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/regular-member-pull-request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/regular-member-pull-request.md
@@ -1,0 +1,17 @@
+---
+name: "\U0001F680 Request to become a Regular Member"
+about: You'd like to participate in the Cross Project Council's work as a Regular Member. Yay!
+---
+
+<!--
+We are thrilled that you'd like to participate in our work in a meaningful way as a Regular Member of the Cross Project Council.
+
+Requirements and rules around becoming a Regular Member can be found in our Governance:
+https://github.com/openjs-foundation/cross-project-council/blob/master/GOVERNANCE.md#approving-and-onboarding-regular-members
+
+Please fill out information below.
+
+Thanks!
+-->
+
+Please describe your recent participation in the work of the foundation or its member projects as described in the [CPC Governance requirements for becoming a Regular Member](https://github.com/openjs-foundation/cross-project-council/blob/master/GOVERNANCE.md#approving-and-onboarding-regular-members)

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -60,9 +60,9 @@ CPC as well as the consensus seeking process.
 Regular members have made a commitment to be involved in an ongoing manner
 and take on roles and responsibilities as outlined below.
 Regular member is implied when membership type is not
-specified. Anyone who has been a member of one of the projects under the
-OpenJS Foundation for at least three months may request to
-become a regular member by opening a PR to add themselves to the list of
+specified. Anyone who has been active in the work of the OpenJS Foundation, 
+one of its member projects or other related activity as described in the CPC Governance 
+may request to become a regular member by opening a PR to add themselves to the list of
 regular members. Regular members remain for as long as they are active
 within the work of the CPC. Regular members who have not been active
 in GitHub, participated in meetings, or other work of the CPC for 3 months may be

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -122,6 +122,8 @@ These members will be elected for a term of 1 year as follows:
 
 ## Approving and Onboarding Regular Members
 
+While our goal in the OpenJS Foundation is to do as much or our work in the public, on occasion, there are private matters and private materials. Voting and Regular members are included in these private matters and have access to private materials. Therefore, we have some requirements in place to ensure a level of involvement in our work and to hold an expectation of professionalism.
+
 ### Requirements to become a regular member: (one of the following is required)
 
 - An active member of a project community or collaboration space which is defined as having recent, sustained contributions to the project during the past 90 days.
@@ -132,9 +134,9 @@ These members will be elected for a term of 1 year as follows:
 - Project representatives from the project the user is claiming affiliation with have the ability to approve/reject the nomination.
 - Voting members from the project the user is claiming affiliation with have the ability to approve/reject the nomination.
 
-Regular members can self-nominate by opening a PR to add themselves to the Regular member list in the [README.md][README]. The PR should include information about how the potential new member has been active in the foundation or its member projects as described above in the requirements section of this document.
+Regular members can self-nominate by opening a PR to add themselves to the Regular member list in the [README.md][README]. The PR should include information about how the potential new member has been active in the foundation or its member projects as described above in the [requirements section](#requirements-to-become-a-regular-member-one-of-the-following-is-required) of this document.
 
-In addition to the requirements above, the PR to add a regular member is approved when:
+In addition to the [requirements above](#requirements-to-become-a-regular-member-one-of-the-following-is-required), the PR to add a regular member is approved when:
 
 * There are no outstanding objections
 * There are two or more approvals by voting CPC members

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -122,7 +122,7 @@ These members will be elected for a term of 1 year as follows:
 
 ## Approving and Onboarding Regular Members
 
-While our goal in the OpenJS Foundation is to do as much or our work in the public, on occasion, there are private matters and private materials. Voting and Regular members are included in these private matters and have access to private materials. Therefore, we have some requirements in place to ensure a level of involvement in our work and to hold an expectation of professionalism.
+Our goal in the OpenJS Foundation is to do most of our work in public. On occasion, there are matters and materials that must be kept private and shared only with Voting and Regular members. As a result we have requirements in place in order to ensure that Voting and Regular members are known and active in the the projects they represent or known to the CPC and active in its work. Observers can participate in almost all aspects of the work of the CPC except those infrequent matters related to private information.
 
 ### Requirements to become a regular member: (one of the following is required)
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -122,9 +122,9 @@ These members will be elected for a term of 1 year as follows:
 
 ## Approving and Onboarding Regular Members
 
-Our goal in the OpenJS Foundation is to do most of our work in public. On occasion, there are matters and materials that must be kept private and shared only with Voting and Regular members. As a result we have requirements in place in order to ensure that Voting and Regular members are known and active in the the projects they represent or known to the CPC and active in its work. Observers can participate in almost all aspects of the work of the CPC except those infrequent matters related to private information.
+Our goal in the OpenJS Foundation is to do most of our work in public. On occasion, there are matters and materials that must be kept private and shared only with Voting and Regular members. As a result we have requirements in place in order to ensure that Voting and Regular members are known and active in the projects they represent or known to the CPC and active in its work. Observers can participate in almost all aspects of the work of the CPC except those infrequent matters related to private information.
 
-### Requirements to become a regular member: (one of the following is required)
+### Requirements to become a Regular member: (one of the following is required)
 
 - An active member of a project community or collaboration space which is defined as having recent, sustained contributions to the project during the past 90 days.
 - A demonstrated level of contribution to the CPC's work (meetings, issues, pull-requests) as an observer during the past 30 days.
@@ -136,7 +136,7 @@ Our goal in the OpenJS Foundation is to do most of our work in public. On occasi
 
 Regular members can self-nominate by opening a PR to add themselves to the Regular member list in the [README.md][README]. The PR should include information about how the potential new member has been active in the foundation or its member projects as described above in the [requirements section](#requirements-to-become-a-regular-member-one-of-the-following-is-required) of this document.
 
-In addition to the [requirements above](#requirements-to-become-a-regular-member-one-of-the-following-is-required), the PR to add a regular member is approved when:
+In addition to the [requirements above](#requirements-to-become-a-regular-member-one-of-the-following-is-required), the PR to add a Regular member is approved when:
 
 * There are no outstanding objections
 * There are two or more approvals by voting CPC members
@@ -145,7 +145,7 @@ In addition to the [requirements above](#requirements-to-become-a-regular-member
 Once a PR is ready to be landed, the CPC member who lands the pull request should:
 
 * Send a notification to the project contacts for the project identified in the PR
-  indicating that a new regular CPC member has joined the CPC on behalf of the project.
+  indicating that a new Regular CPC member has joined the CPC on behalf of the project.
 * Add the member to the github `cpc-regular-members` [team][cpc regular members team]
 * Add the member to the `cpc-private` email list
 * Introduce the new member at the next CPC meeting.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -215,6 +215,5 @@ CPC members may request fast-tracking of pull requests they did not author. In t
 [cpc charter]: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md
 [cpc charter term]: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#voting-members
 [CPC charter section 5]: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#section-5-responsibilities-and-expectations-of-the-cpc
-[cpc charter regular members]: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#regular-members
 [cpc regular members team]: https://github.com/orgs/openjs-foundation/teams/cpc-regular-members
 [README]: ./README.md

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -122,9 +122,19 @@ These members will be elected for a term of 1 year as follows:
 
 ## Approving and Onboarding Regular Members
 
-Regular members can self-nominate by opening a PR to add themselves to the Regular member list in the [README.md][README]. The PR should include an indication of which project they have been active in for 3 months as per the [CPC charter][cpc charter regular members].
+### Requirements to become a regular member: (one of the following is required)
 
-The PR to add a regular member is approved when:
+- An active member of a project community or collaboration space which is defined as having recent, sustained contributions to the project during the past 90 days.
+- A demonstrated level of contribution to the CPC's work (meetings, issues, pull-requests) as an observer during the past 30 days.
+
+### Means for approval/rejection, if citing project affiliation: (one of the following approvals is required)
+
+- Project representatives from the project the user is claiming affiliation with have the ability to approve/reject the nomination.
+- Voting members from the project the user is claiming affiliation with have the ability to approve/reject the nomination.
+
+Regular members can self-nominate by opening a PR to add themselves to the Regular member list in the [README.md][README]. The PR should include information about how the potential new member has been active in the foundation or its member projects as described above in the requirements section of this document.
+
+In addition to the requirements above, the PR to add a regular member is approved when:
 
 * There are no outstanding objections
 * There are two or more approvals by voting CPC members

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ According to the [CPC Charter](https://github.com/openjs-foundation/cross-projec
 
 ### Regular Members
 
-According to the [CPC Charter](https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#regular-members) anyone who has been a member of one of the projects under the OpenJS Foundation for at least three months may request to become a regular member by opening a PR to add themselves to the list of regular members
+Anyone who has been active in the foundation or one of its member projects, as described in the [CPC Governance](https://github.com/openjs-foundation/cross-project-council/blob/master/GOVERNANCE.md#approving-and-onboarding-regular-members) may request to become a regular member by opening a PR to add themselves to the list of regular members.
 
 - Abraham Jr Agiri (@codeekage)
 - Antón Molleda (@molant)


### PR DESCRIPTION
I made changes as laid out in https://github.com/openjs-foundation/cross-project-council/issues/513.

I moved requirements to GOVERNANCE and reference those requirements in README and CHARTER so that we have one place for the details and if we change them in the future, we dont need to change our charter, only our governance.

**Since this PR changes both Governance and Charter, the following conditions must be met:**

- [x] The PR has been open for at least 14 days OR consensus is reached in a meeting with quorum of voting members.
- [x] The text of the PR must be approved by a simple majority of the voting members. (6 of 11 Voting Members)
- [ ] The text of the PR must be approved by the board.

Approvals from Voting Members (need 6 of 11):
- [x] @imurchie
- [x] @Jonahss
- [x] @dylans
- [x] @dmethvin
- [x] @timmywil
- [x] @mcollina
- [x] @joesepi
- [ ] @TheLarkInn
- [ ] @sokra
- [x] @boneskull
- [x] @tobie