### PR TITLE
Add "Reason for Applying" to new project template

### DIFF
--- a/NEW_PROJECT_APPLICATION.md
+++ b/NEW_PROJECT_APPLICATION.md
@@ -8,6 +8,10 @@ Who is the main point of contact during the application process?
 
 A rough description of the project in less than 100 words.
 
+## Reason for Applying
+
+A short description of the reasons why your project is applying to join the foundation, and your expectations from the foundation.
+
 ## Statement of alignment with OpenJS Foundation charter and mission
 
 Please refer to [the Cross Project Council's Charter](https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md).


### PR DESCRIPTION
Projects of various sizes apply to join the foundation for a variety of reasons, and they hold a variety of expectations on what membership of the foundation may bring them. Most of these are entirely valid, but we can't always know that.

Hence I think we should directly ask applicants why they'd like to join, and what they expect to benefit from their membership. This should make it much easier for the CPC to evaluate applications, and for any misunderstandings to be corrected as early as possible.