### PR TITLE
Board seat definitions and process

### DIFF
--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -245,7 +245,7 @@ The first of these board seats is filled by the CPC Director as outlined in Sect
 
 **CPC Director eligibility:** The CPC Director must be a current CPC Member
 
-**CPC Director voting:** CPC Members will vote on candidates
+**CPC Director voting:** CPC Members (Voting and Regular) will vote on candidates
 
 ### Community Director
 
@@ -256,7 +256,7 @@ processes once per year.
 
 **Community Director eligibility:** The Community Director must be an [Active OpenJS Collaborator][] at the time of their selection, as defined in the CPC's Governance document.
 
-**Community Director voting:** CPC Members will vote on candidates
+**Community Director voting:** CPC Members (Voting and Regular) will vote on candidates
 
 As described in the [Elections][] section a multiple candidate method
 will be be used for the voting for the first and second board members.

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -237,31 +237,31 @@ CPC Chairperson or Director may serve.
 ## Section 8. Board Representation
 
 There are 3 Board seats earmarked for representation from the
-OpenJS Foundation projects.
+OpenJS Foundation, the Foundation's projects, and related communities.
 
-### CPC Director
+### The Primary CPC Director (as defined in §4.3(d) in the [OpenJS Foundation bylaws][])
 
-The first of these board seats is filled by the CPC Director as outlined in Section 7 on [Elections][] and is always in place.
+The first of these board seats is filled as outlined in Section 7 on [Elections][] and is always in place.
 
-**CPC Director eligibility:** The CPC Director must be a current CPC Member
+**Primary CPC Director eligibility:** The Primary CPC Director must be a current CPC Member
 
-**CPC Director voting:** CPC Members (Voting and Regular) will vote on candidates
+**Primary CPC Director voting:** CPC Voting Members will vote on candidates
 
-### Community Director
+### The Secondary CPC Director (as defined in §4.3(e) in the[OpenJS Foundation bylaws][])
 
 The second board seat will be filled based on processes defined
 by the CPC and approved by the Voting CPC members and then the Board. The
 CPC members will review and either re-confirm or update the
 processes once per year.
 
-**Community Director eligibility:** The Community Director must be an [Active OpenJS Collaborator][] at the time of their selection, as defined in the CPC's Governance document.
+**Secondary Director eligibility:** The Second CPC Director must be an [Active OpenJS Collaborator][] at the time of their selection, as defined in the CPC's Governance document.
 
-**Community Director voting:** CPC Members (Voting and Regular) will vote on candidates
+**Secondary Director voting:** CPC Voting Members will vote on candidates
 
 As described in the [Elections][] section a multiple candidate method
 will be be used for the voting for the first and second board members.
 
-### Individual Membership Director
+### The Tertiary CPC Director (as defined in §4.3(f) in the [OpenJS Foundation bylaws][])
 
 The third board seat is earmarked to represent the Individual membership
 program. 3 Platinum board members as well as 2000 members registered in the
@@ -327,3 +327,4 @@ policies.
 [Condorcet]: http://en.wikipedia.org/wiki/Condorcet_method
 [Single Transferable Vote]: http://en.wikipedia.org/wiki/Single_transferable_vote
 [Active OpenJS Collaborator]: https://github.com/openjs-foundation/cross-project-council/blob/master/GOVERNANCE.md#definition-of-an-active-openjs-collaborator
+[OpenJS Foundation bylaws]: https://bylaws.openjsf.org/

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -261,7 +261,7 @@ processes once per year.
 As described in the [Elections][] section a multiple candidate method
 will be be used for the voting for the first and second board members.
 
-### At-Large Director
+### Individual Membership Director
 
 The third board seat is earmarked to represent the Individual membership
 program. 3 Platinum board members as well as 2000 members registered in the

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -321,8 +321,8 @@ policies.
 
 [Foundation mission and vision statements]:  https://openjsf.org/about/
 [Foundation bylaws]:  https://bylaws.openjsf.org
-[Voting]:  #section-10.-voting
-[Elections]: #section-7.-elections
+[Voting]:  #section-10-voting
+[Elections]: #section-7-elections
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Condorcet]: http://en.wikipedia.org/wiki/Condorcet_method
 [Single Transferable Vote]: http://en.wikipedia.org/wiki/Single_transferable_vote

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -226,7 +226,7 @@ the candidates election. Elections shall be done within the Projects by
 the Collaborators active in the Project.
 
 
-The CPC will elect from amongst voting CPC members a CPC Chairperson to
+The CPC will elect from amongst CPC members a CPC Chairperson to
 work on building an agenda for CPC meetings and a CPC Director to represent
 the CPC to the Board for a term of one year according to the OpenJS Foundation’s
 By-laws. The Chair and Director may be (but are not required to be)
@@ -237,26 +237,31 @@ CPC Chairperson or Director may serve.
 ## Section 8. Board Representation
 
 There are 3 Board seats earmarked for representation from the
-OpenJS Foundation projects.  The first of these board seats is filled by
-the CPC Director as outlined in Section 7 on [Elections][] and is
-always in place.  
+OpenJS Foundation projects.
 
-The second board seat requires 2 Platinum board members to activate
-and will be filled based on processes defined
+### CPC Director
+
+The first of these board seats is filled by the CPC Director as outlined in Section 7 on [Elections][] and is always in place.
+
+**CPC Director eligibility:** The CPC Director must be a current CPC Member
+
+**CPC Director voting:** CPC Members will vote on candidates
+
+### Community Director
+
+The second board seat will be filled based on processes defined
 by the CPC and approved by the Voting CPC members and then the Board. The
 CPC members will review and either re-confirm or update the
 processes once per year.
 
-For the first year after the formation of the OpenJS Foundation, the
-processes for filling this seat will be as follows:
+**Community Director eligibility:** The Community Director must be an Active OpenJS Collaborator as defined in the CPC's Governance document.
 
-* As a constellation member of the OpenJS Foundation, the Node.js project
-  will elect one Board representative from either the Technical Steering Committee (TSC) or
-  Community Committee (CommComm). The representative will be selected according to a process
-  defined by the TSC and CommComm.
+**Community Director voting:** CPC Members will vote on candidates
 
 As described in the [Elections][] section a multiple candidate method
 will be be used for the voting for the first and second board members.
+
+### At-Large Director
 
 The third board seat is earmarked to represent the Individual membership
 program. 3 Platinum board members as well as 2000 members registered in the

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -254,7 +254,7 @@ by the CPC and approved by the Voting CPC members and then the Board. The
 CPC members will review and either re-confirm or update the
 processes once per year.
 
-**Community Director eligibility:** The Community Director must be an [Active OpenJS Collaborator][] as defined in the CPC's Governance document.
+**Community Director eligibility:** The Community Director must be an [Active OpenJS Collaborator][] at the time of their selection, as defined in the CPC's Governance document.
 
 **Community Director voting:** CPC Members will vote on candidates
 

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -254,7 +254,7 @@ by the CPC and approved by the Voting CPC members and then the Board. The
 CPC members will review and either re-confirm or update the
 processes once per year.
 
-**Community Director eligibility:** The Community Director must be an Active OpenJS Collaborator as defined in the CPC's Governance document.
+**Community Director eligibility:** The Community Director must be an [Active OpenJS Collaborator][] as defined in the CPC's Governance document.
 
 **Community Director voting:** CPC Members will vote on candidates
 
@@ -326,3 +326,4 @@ policies.
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Condorcet]: http://en.wikipedia.org/wiki/Condorcet_method
 [Single Transferable Vote]: http://en.wikipedia.org/wiki/Single_transferable_vote
+[Active OpenJS Collaborator]: https://github.com/openjs-foundation/cross-project-council/blob/master/GOVERNANCE.md#definition-of-an-active-openjs-collaborator

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -158,6 +158,8 @@ _Note: Former Voting members whose terms have just ended will automatically beco
 - An active member of a project community or collaboration space which is defined as having recent, sustained contributions to the project during the past 90 days.
 - A demonstrated level of contribution to the CPC's work (meetings, issues, pull-requests) as an observer during the past 30 days.
 
+_Note: Contributions can include, but are not limited to, participation in: meetings, issues or pull-requests._
+
 ## Approving Project Charters
 
 Per the [CPC charter section 5][], the voting CPC members are responsible for approving project

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -133,9 +133,9 @@ One must already be an [Active OpenJS Collaborator][], as described below, to be
 - Project representatives from the project the user is claiming affiliation with have the ability to approve/reject the nomination.
 - Voting members from the project the user is claiming affiliation with have the ability to approve/reject the nomination.
 
-Regular members can self-nominate by opening a PR to add themselves to the Regular member list in the [README.md][README]. The PR should include information about how the potential new member has been active in the foundation or its member projects as described below in the [Active OpenJS Collaborator][] of this document.
+Regular members can self-nominate by opening a PR to add themselves to the Regular member list in the [README.md][README]. The PR should include information about how the potential new member has been active in the foundation or its member projects as described below in the [Active OpenJS Collaborator][] section of this document.
 
-In addition to the [Active OpenJS Collaborator][], the PR to add a Regular member is approved when:
+In addition to being an [Active OpenJS Collaborator][], the PR to add a Regular member is approved when:
 
 * There are no outstanding objections
 * There are two or more approvals by voting CPC members

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -146,7 +146,7 @@ Once a PR is ready to be landed, the CPC member who lands the pull request shoul
 * Send a notification to the project contacts for the project identified in the PR
   indicating that a new Regular CPC member has joined the CPC on behalf of the project.
 * Add the member to the github `cpc-regular-members` [team][cpc regular members team]
-* Add the member to the `cpc-private` email list and directory by opening a PR against the [OpenJS Foundation directory][]
+* Add the member to the `cpc-private` email list and private directory by opening a PR against the [OpenJS Foundation CPC directory][]
 * Introduce the new member at the next CPC meeting.
 
 _Note: Former Voting members whose terms have just ended will automatically become Regular members, unless they indicate otherwise._
@@ -231,4 +231,4 @@ CPC members may request fast-tracking of pull requests they did not author. In t
 [OpenJS Foundation Directory]: https://github.com/openjs-foundation/directory-private/blob/master/cpc-private.md
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Active OpenJS Collaborator]: #definition-of-an-active-openjs-collaborator
-[OpenJS Foundation directory]: https://github.com/openjs-foundation/directory-private/blob/master/groups/cross-project-council.yml
+[OpenJS Foundation CPC directory]: https://github.com/openjs-foundation/directory-private/blob/master/groups/cross-project-council.yml

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -126,20 +126,18 @@ These members will be elected for a term of 1 year as follows:
 
 Our goal in the OpenJS Foundation is to do most of our work in public. On occasion, there are matters and materials that must be kept private and shared only with Voting and Regular members. As a result we have requirements in place in order to ensure that Voting and Regular members are known and active in the projects they represent or known to the CPC and active in its work. Observers can participate in almost all aspects of the work of the CPC except those infrequent matters related to private information.
 
-### Requirements to become a Regular member: (one of the following is required)
+### Eligibility to become a Regular member
 
-- An active member of a project community or collaboration space which is defined as having recent, sustained contributions to the project during the past 90 days.
-- A demonstrated level of contribution to the CPC's work (meetings, issues, pull-requests) as an observer during the past 30 days.
-- A former Voting member whose term has just ended.
+One must already be an [Active OpenJS Collaborator](#definition-of-an-active-openjs-collaborator), as described below, to be eligible to become a Regular Member of the CPC.
 
 ### Means for approval/rejection, if citing project affiliation: (one of the following approvals is required)
 
 - Project representatives from the project the user is claiming affiliation with have the ability to approve/reject the nomination.
 - Voting members from the project the user is claiming affiliation with have the ability to approve/reject the nomination.
 
-Regular members can self-nominate by opening a PR to add themselves to the Regular member list in the [README.md][README]. The PR should include information about how the potential new member has been active in the foundation or its member projects as described above in the [requirements section](#requirements-to-become-a-regular-member-one-of-the-following-is-required) of this document.
+Regular members can self-nominate by opening a PR to add themselves to the Regular member list in the [README.md][README]. The PR should include information about how the potential new member has been active in the foundation or its member projects as described below in the [Active OpenJS Collaborator section](#definition-of-an-active-openjs-collaborator) of this document.
 
-In addition to the [requirements above](#requirements-to-become-a-regular-member-one-of-the-following-is-required), the PR to add a Regular member is approved when:
+In addition to the [Active OpenJS Collaborator requirement](#definition-of-an-active-openjs-collaborator), the PR to add a Regular member is approved when:
 
 * There are no outstanding objections
 * There are two or more approvals by voting CPC members
@@ -153,7 +151,14 @@ Once a PR is ready to be landed, the CPC member who lands the pull request shoul
 * Add the member to the `cpc-private` email list and directory by opening a PR against the [OpenJS Foundation directory](https://github.com/openjs-foundation/directory-private/blob/master/groups/cross-project-council.yml)
 * Introduce the new member at the next CPC meeting.
 
-Former Voting members whose terms have just ended will automatically become Regular members, unless they indicate otherwise.
+_Note: Former Voting members whose terms have just ended will automatically become Regular members, unless they indicate otherwise._
+
+## Definition of an Active OpenJS Collaborator
+
+### To be considered An active OpenJS Collaborator, one of the following is required:
+
+- An active member of a project community or collaboration space which is defined as having recent, sustained contributions to the project during the past 90 days.
+- A demonstrated level of contribution to the CPC's work (meetings, issues, pull-requests) as an observer during the past 30 days.
 
 ## Approving Project Charters
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -153,12 +153,12 @@ _Note: Former Voting members whose terms have just ended will automatically beco
 
 ## Definition of an Active OpenJS Collaborator
 
-### To be considered An active OpenJS Collaborator, one of the following is required:
+### To be considered an active OpenJS Collaborator, one of the following is required:
 
-- An active member of a project community or collaboration space which is defined as having recent, sustained contributions to the project during the past 90 days.
-- A demonstrated level of contribution to the CPC's work (meetings, issues, pull-requests) as an observer during the past 30 days.
+- Activity within a project, community, or collaboration space.
+- A demonstrated level of contribution to the CPC's work during the past 30 days.
 
-_Note: Contributions can include, but are not limited to, participation in meetings, issues or pull-requests, editing documentation, community management, marketing, organizing events, as well as similar activities as they relate to the OpenJS Foundation and its member projects._
+_Note: "Activity" is defined as recent, sustained contributions during the past 90 days. Contributions can include, but are not limited to, participation in meetings, issues or pull-requests, editing documentation, community management, marketing, organizing events, as well as similar activities as they relate to the OpenJS Foundation and its member projects._
 
 ## Approving Project Charters
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -158,7 +158,7 @@ _Note: Former Voting members whose terms have just ended will automatically beco
 - An active member of a project community or collaboration space which is defined as having recent, sustained contributions to the project during the past 90 days.
 - A demonstrated level of contribution to the CPC's work (meetings, issues, pull-requests) as an observer during the past 30 days.
 
-_Note: Contributions can include, but are not limited to, participation in meetings, issues or pull-requests, editing documentation, community management, marketing, organizing events, etc._
+_Note: Contributions can include, but are not limited to, participation in meetings, issues or pull-requests, editing documentation, community management, marketing, organizing events, as well as similar activities as they relate to the OpenJS Foundation and its member projects._
 
 ## Approving Project Charters
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,10 +1,10 @@
 # OpenJS Cross Project Council
 
-For the current list of Team members, see the project [README.md][README] and the [OpenJS Foundation Directory](https://github.com/openjs-foundation/directory-private/blob/master/cpc-private.md) (restricted access for privacy reasons).
+For the current list of Team members, see the project [README.md][README] and the [OpenJS Foundation Directory][] (restricted access for privacy reasons).
 
 ## Members
 
-The [openjs-foundation/cross-project-council](https://github.com/openjs-foundation/cross-project-council) GitHub
+The [openjs-foundation/cross-project-council][cpc repo] GitHub
 repository is maintained by the Team and additional Members who are
 added on an ongoing basis.
 
@@ -50,9 +50,7 @@ agenda item and sends it as a pull request after the meeting.
 
 ## Consensus Seeking Process
 
-The Team follows a
-[Consensus Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making)
-decision-making model.
+The Team follows a [Consensus Seeking][] decision-making model.
 
 When an agenda item has appeared to reach a consensus, the moderator
 will ask "Does anyone object?" as a final call for dissent from the
@@ -128,16 +126,16 @@ Our goal in the OpenJS Foundation is to do most of our work in public. On occasi
 
 ### Eligibility to become a Regular member
 
-One must already be an [Active OpenJS Collaborator](#definition-of-an-active-openjs-collaborator), as described below, to be eligible to become a Regular Member of the CPC.
+One must already be an [Active OpenJS Collaborator][], as described below, to be eligible to become a Regular Member of the CPC.
 
 ### Means for approval/rejection, if citing project affiliation: (one of the following approvals is required)
 
 - Project representatives from the project the user is claiming affiliation with have the ability to approve/reject the nomination.
 - Voting members from the project the user is claiming affiliation with have the ability to approve/reject the nomination.
 
-Regular members can self-nominate by opening a PR to add themselves to the Regular member list in the [README.md][README]. The PR should include information about how the potential new member has been active in the foundation or its member projects as described below in the [Active OpenJS Collaborator section](#definition-of-an-active-openjs-collaborator) of this document.
+Regular members can self-nominate by opening a PR to add themselves to the Regular member list in the [README.md][README]. The PR should include information about how the potential new member has been active in the foundation or its member projects as described below in the [Active OpenJS Collaborator][] of this document.
 
-In addition to the [Active OpenJS Collaborator requirement](#definition-of-an-active-openjs-collaborator), the PR to add a Regular member is approved when:
+In addition to the [Active OpenJS Collaborator][], the PR to add a Regular member is approved when:
 
 * There are no outstanding objections
 * There are two or more approvals by voting CPC members
@@ -148,7 +146,7 @@ Once a PR is ready to be landed, the CPC member who lands the pull request shoul
 * Send a notification to the project contacts for the project identified in the PR
   indicating that a new Regular CPC member has joined the CPC on behalf of the project.
 * Add the member to the github `cpc-regular-members` [team][cpc regular members team]
-* Add the member to the `cpc-private` email list and directory by opening a PR against the [OpenJS Foundation directory](https://github.com/openjs-foundation/directory-private/blob/master/groups/cross-project-council.yml)
+* Add the member to the `cpc-private` email list and directory by opening a PR against the [OpenJS Foundation directory][]
 * Introduce the new member at the next CPC meeting.
 
 _Note: Former Voting members whose terms have just ended will automatically become Regular members, unless they indicate otherwise._
@@ -167,7 +165,7 @@ charters and changes to them.
 
 Approval of the initial charter or changes to an existing charter will
 be requested by opening an issue requesting approval in the cross-project-council
-[repository](https://github.com/openjs-foundation/cross-project-council/).
+[repository][cpc repo].
 
 The request is approved when:
 
@@ -222,8 +220,13 @@ The pull request may be fast-tracked if two CPC members approve the fast-trackin
 
 CPC members may request fast-tracking of pull requests they did not author. In that case only, the request itself is also one fast-track approval. Upvote the comment anyway to avoid any doubt.
 
+[cpc repo]: https://github.com/openjs-foundation/cross-project-council
 [cpc charter]: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md
 [cpc charter term]: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#voting-members
 [CPC charter section 5]: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#section-5-responsibilities-and-expectations-of-the-cpc
 [cpc regular members team]: https://github.com/orgs/openjs-foundation/teams/cpc-regular-members
 [README]: ./README.md
+[OpenJS Foundation Directory]: https://github.com/openjs-foundation/directory-private/blob/master/cpc-private.md
+[Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
+[Active OpenJS Collaborator]: #definition-of-an-active-openjs-collaborator
+[OpenJS Foundation directory]: https://github.com/openjs-foundation/directory-private/blob/master/groups/cross-project-council.yml

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -158,7 +158,7 @@ _Note: Former Voting members whose terms have just ended will automatically beco
 - An active member of a project community or collaboration space which is defined as having recent, sustained contributions to the project during the past 90 days.
 - A demonstrated level of contribution to the CPC's work (meetings, issues, pull-requests) as an observer during the past 30 days.
 
-_Note: Contributions can include, but are not limited to, participation in: meetings, issues or pull-requests._
+_Note: Contributions can include, but are not limited to, participation in meetings, issues or pull-requests, editing documentation, community management, marketing, organizing events, etc._
 
 ## Approving Project Charters
 


### PR DESCRIPTION
This is part of the work to define Board seat definitions and process.

As a first step, I've abstracted out the definition of an Active OpenJS Collaborator in our Governance.

Secondly, I've tried to capture a simple explanation of the 2 of the 3 board seats.

Also, there was a mixture of markdown link definitions, so I updated links so that they defined at the bottom of the doc.