### PR TITLE
Drop charter mention of Commons.js

### DIFF
--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -130,8 +130,7 @@ Voting members have the roles and responsibilities as outlined below.
 
 ## Section 5. Responsibilities and Expectations of the CPC
 
-Subject to such policies as may be set by the Board, the CPC is responsible for
-ensuring:
+Subject to such policies as may be set by the Board, the CPC is responsible for:
 
    1. When needed, members of the CPC will be expected to create subcommittees
       or working groups. The CPC will delegate responsibilities and empower
@@ -170,8 +169,7 @@ ensuring:
    1. Managing the Individual membership program.
    1. Managing programs to improve inclusivity and diversity.
    1. Guiding projects into appropriate Foundation paths.
-   1. Shared resources, tooling and funding for projects and Commons.js (Events
-      Collaborator Summit, Travel fund).
+   1. Shared resources, tooling and funding for projects (Collaborator Summit Events, Travel fund).
    1. Supporting projects in their enforcement of Code of Conduct
       violations and escalation.
    1. Developing a framework for community end-user feedback.


### PR DESCRIPTION
Closes #95 

As discussed in [this week's CPC meeting](https://github.com/openjs-foundation/cross-project-council/issues/594), we've done nothing to advance the Commons.js program for the past year and a half. At that time it was left with the intention of someone putting together a stage-0 proposal, but that never happened. We have, however, advanced other proposals (such as Collaboration Networks) that may provide some of the support for smaller projects as was envisioned to happen via Commons.js.

We should admit that while it was a fine idea, it's clearly not advancing as was desired. We should drop it for now, while possibly picking it back up later if a clearer, more concrete plan for it can be formed.

The thing though is that our charter mentions the Commons.js program. Therefore this PR is a change that'll [need the following](https://github.com/openjs-foundation/cross-project-council/blob/master/GOVERNANCE.md#merging-prs-into-this-repository) to be accepted:
- The PR has been open for at least 14 days OR consensus is reached in a meeting with quorum of voting members.
- The text of the PR must be approved by a simple majority of the voting members.
- The text of the PR must be approved by the board.

While that all is a hassle, I at least think that it should be done. As is, we as the CPC are taking responsibility for providing "resources, tooling and funding" to something that we haven't even clearly defined. That doesn't feel like a good idea. The alternative, of course, is for someone to start actively championing the Commons.js program, and thereby let us know what we've signed up to do.