### PR TITLE
Add IP Policy guidance

### DIFF
--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -68,7 +68,7 @@ right to make the contribution under the open source license.
 Alternately, projects may decide to adopt a CLA. In this case each contributor
 must be covered by a signed CLA, either as an individual contributor on their
 own behalf or from their employer. The OpenJS Foundation Board of Directors has
-pre-approved an [Individual CLA](ICLA) and a [Corporate CLA](CCLA) which
+pre-approved an [Individual CLA][ICLA] and a [Corporate CLA][CCLA] which
 projects can adopt without any further review. The decision to adopt a CLA is
 left to each project's governing body.
 

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -67,7 +67,7 @@ and a [Corporate CLA (CCLA)][CCLA]
 which projects can adopt without any further review.
 
 If you need to use a different CLA, you will need to
-[require an exemption from the board](#requiring-an-exemption-from-the-board).
+[obtaining an exemption from the board](#obtaining-an-exemption-from-the-board).
 
 We are preparing additional guidance documentation on how to implement the DCO or a CLA,
 what infrastructure the foundation provides to help with this,

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -10,13 +10,12 @@ first read the [IP Policy][], and then [ask for help](#getting-help).
 
 ## Basic requirements
 
-There are three key requirements for all OpenJS Foundation projects:
+There are four key requirements for all OpenJS Foundation projects:
 
-1. [Licensing](#1-licensing),
-2. [copyright notices](#2-copyright-notices), and
-3. displaying the [standard website footer](#3-standard-website-footer) on the project's website.
-
-Additionally, projects may decide to adopt the [OpenJS Foundation Contributor License Agreement (CLA)](#contributor-license-agreement-cla).
+1. [Licensing](#1-licensing)
+2. [Copyright notices](#2-copyright-notices)
+3. Displaying the [standard website footer](#3-standard-website-footer) on the project's website
+4. Choose between the [DCO]() or a [Contributor License Agreement (CLA)](#4-contributor-license-agreement-cla)
 
 ### 1. Licensing
 
@@ -30,7 +29,7 @@ Documentation may be licensed under:
   * [CC BY 4.0](http://creativecommons.org/licenses/by/4.0/)
   * [MIT](https://opensource.org/licenses/MIT)
 
-If you need to use a license which isn't in the list,
+If you need to use a license which isn't in the [IP Policy],
 you will need to obtain permission from the Board to do so.
 
 ### 2. Copyright notices
@@ -58,14 +57,34 @@ as this simply reflects the merged status of the organizations._
 
 All project websites need to have a [standard website footer][].
 
-### Contributor License Agreement (CLA)
+### 4. Contributor License Agreement (CLA)
 
-Projects may decide to adopt the [OpenJS Foundation CLA][CLA] but may not use other CLAs.
+By default the OpenJS Foundation uses the [DCO](), which means contributors
+submit their contributions under the project's designated open source license.
+Every commit must contain a Signed-off-by line in the commit message (e.g.,
+`Signed-off-by: Authorname <author@email.com>`), indicating the author has the
+right to make the contribution under the open source license.
+
+Alternately, projects may decide to adopt a CLA. In this case each contributor
+must be covered by a signed CLA, either as an individual contributor on their
+own behalf or from their employer. The OpenJS Foundation Board of Directors has
+pre-approved an [Individual CLA](ICLA) and a [Corporate CLA](CCLA) which
+projects can adopt without any further review. The decision to adopt a CLA is
+left to each project's governing body.
+
+When a contributor signs the default OpenJS Foundation CLA in one project, they
+will automatically be covered for any other project which uses the same CLA.
+
+To use the CLA with your project, or if there are special circumstances that
+may require a different CLA, please contact
+[legal-questions@lists.openjsf.org](mailto:legal-questions@lists.openjsf.org).
 
 ## Getting help
 
 If you have a question about this policy or how to implement it, please reach out to [legal-questions@lists.openjsf.org](mailto:legal-questions@lists.openjsf.org).
 
 [IP Policy]: https://ip-policy.openjsf.org
-[CLA]: https://cla.openjsf.org
+[DCO]: https://developercertificate.org
+[ICLA]: https://individual-cla.openjsf.org
+[CCLA]: https://corporate-cla.openjsf.org
 [standard website footer]: https://github.com/openjs-foundation/artwork#copyright-notices-for-project-website-footers

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -77,7 +77,7 @@ and how to fix common issues that arise when using either solution.
 To setup the CLA infrastructure until this additional documentation is ready,
 please [reach out to foundation staff](#getting-help).
 
-## Requiring an exemption from the Board
+## Obtaining an exemption from the Board
 
 If your project requires an exemption from the [IP Policy][],
 you will need to obtain special permission from the Board.

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -29,10 +29,8 @@ Documentation may be licensed under:
   * [CC BY 4.0](http://creativecommons.org/licenses/by/4.0/)
   * [MIT](https://opensource.org/licenses/MIT)
 
-If you need to use a license which isn't in the [IP Policy][],
-you will need to obtain permission from the Board to do so.
-Please [open an issue in the CPC repository](https://github.com/openjs-foundation/cross-project-council/issues/new),
-and assign it to @brianwarner.
+If you need to use a license which isn't in the [IP Policy][], you will
+[need to obtain permission from the Board to do so](#requiring-an-exemption-from-the-board).
 
 ### 2. Copyright notices
 

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -1,0 +1,71 @@
+# OpenJS Foundation IP Policy Guidance
+
+The purpose of this guide is to make it straightforward for projects
+to follow the [OpenJS Foundation IP Policy][IP Policy].
+
+Of course, the source of truth remains the [IP Policy][].
+
+If in doubt about anything related to IP after reading this document,
+first read the [IP Policy][], and then [ask for help](#getting-help).
+
+## Basic requirements
+
+There are three key requirements for all OpenJS Foundation projects:
+
+1. [Licensing](#1-licensing),
+2. [copyright notices](#2-copyright-notices), and
+3. displaying the [standard website footer](#3-standard-website-footer) on the project's website.
+
+Additionally, projects may decide to adopt the [OpenJS Foundation Contributor License Agreement (CLA)](#contributor-license-agreement-cla).
+
+### 1. Licensing
+
+Code may be licensed under:
+  * [Apache, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+  * [MIT](https://opensource.org/licenses/MIT)
+  * [2-Clause BSD](https://opensource.org/licenses/BSD-2-Clause)
+  * [3-Clause BSD](https://opensource.org/licenses/BSD-3-Clause)
+
+Documentation may be licensed under:
+  * [CC BY 4.0](http://creativecommons.org/licenses/by/4.0/)
+  * [MIT](https://opensource.org/licenses/MIT)
+
+If you need to use a license which isn't in the list,
+you will need to obtain permission from the Board to do so.
+
+### 2. Copyright notices
+
+The recommendation is to use a general copyright statement
+of the following form (where XYZ is the project's name):
+
+- **Copyright The XYZ Authors.**
+- **Copyright The XYZ Contributors.**
+- **Copyright Contributors to the XYZ project.**
+
+By using this format, the project avoids having to deal with
+names of copyright holders, years or ranges of years,
+and variations on the (c) symbol.
+
+_Please note that you **must not** change or remove existing copyright lines
+unless you put them there **and** have the right to do so.
+If there are existing copyright lines just
+add the recommended copyright statement below the existing copyright lines.
+You may however update copyright lines that say
+"JS Foundation" or "Node.js Foundation" to "OpenJS Foundation"
+as this simply reflects the merged status of the organizations._
+
+### 3. Standard website footer
+
+All project websites need to have a [standard website footer][].
+
+### Contributor License Agreement (CLA)
+
+Projects may decide to adopt the [OpenJS Foundation CLA][CLA] but may not use other CLAs.
+
+## Getting help
+
+If you have a question about this policy or how to implement it, please reach out to [legal-questions@lists.openjsf.org](mailto:legal-questions@lists.openjsf.org).
+
+[IP Policy]: https://ip-policy.openjsf.org
+[CLA]: https://cla.openjsf.org
+[standard website footer]: https://github.com/openjs-foundation/artwork#copyright-notices-for-project-website-footers

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -61,7 +61,7 @@ All project websites need to have a [standard website footer][].
 
 ### 4. Adopting the DCO or a CLA
 
-Each project much adopt either the [Developer Certificate of Origin (DCO)][DCO]
+Each project must adopt either the [Developer Certificate of Origin (DCO)][DCO]
 or a Contributor License Agreement (CLA).
 
 The Board has pre-approved an [Individual CLA (ICLA)][ICLA]

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -15,7 +15,7 @@ There are four key requirements for all OpenJS Foundation projects:
 1. [Licensing](#1-licensing)
 2. [Copyright notices](#2-copyright-notices)
 3. Displaying the [standard website footer](#3-standard-website-footer) on the project's website
-4. Choose between the [DCO]() or a [Contributor License Agreement (CLA)](#4-contributor-license-agreement-cla)
+4. Choose between the [DCO][] or a [Contributor License Agreement (CLA)](#4-contributor-license-agreement-cla)
 
 ### 1. Licensing
 
@@ -59,7 +59,7 @@ All project websites need to have a [standard website footer][].
 
 ### 4. Contributor License Agreement (CLA)
 
-By default the OpenJS Foundation uses the [DCO](), which means contributors
+By default the OpenJS Foundation uses the [DCO][], which means contributors
 submit their contributions under the project's designated open source license.
 Every commit must contain a Signed-off-by line in the commit message (e.g.,
 `Signed-off-by: Authorname <author@email.com>`), indicating the author has the

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -31,7 +31,7 @@ Documentation may be licensed under:
 
 If you need to use a license which isn't in the [IP Policy][],
 you will need to obtain permission from the Board to do so.
-Please [open an issue in the CPC repository][new cpc issue],
+Please [open an issue in the CPC repository](https://github.com/openjs-foundation/cross-project-council/issues/new),
 and assign it to @brianwarner.
 
 ### 2. Copyright notices

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -30,7 +30,7 @@ Documentation may be licensed under:
   * [MIT](https://opensource.org/licenses/MIT)
 
 If you need to use a license which isn't in the [IP Policy][], you will
-[need to obtain permission from the Board to do so](#requiring-an-exemption-from-the-board).
+[need to obtain permission from the Board to do so](#obtaining-an-exemption-from-the-board).
 
 ### 2. Copyright notices
 

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -71,7 +71,13 @@ which projects can adopt without any further review.
 If you need to use a different CLA, you will need to
 [require an exemption from the board](#requiring-an-exemption-from-the-board).
 
-To setup the CLA infrastructure, [reach out to the foundation staff](#getting-help).
+We are preparing additional guidance documentation on how to implement the DCO or a CLA,
+what infrastructure the foundation provides to help with this,
+what steps maintainers need to make when merging pull requests,
+and how to fix common issues that arise when using either solution.
+
+To setup the CLA infrastructure until this additional documentation is ready,
+please [reach out to foundation staff](#getting-help).
 
 ## Requiring an exemption from the Board
 

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -15,7 +15,7 @@ There are four key requirements for all OpenJS Foundation projects:
 1. [Licensing](#1-licensing)
 2. [Copyright notices](#2-copyright-notices)
 3. Displaying the [standard website footer](#3-standard-website-footer) on the project's website
-4. Choose between the [DCO][] or a [Contributor License Agreement (CLA)](#4-contributor-license-agreement-cla)
+4. [Adopting the DCO or a CLA](#4-adopting-the-dco-or-a-cla)
 
 ### 1. Licensing
 
@@ -30,7 +30,9 @@ Documentation may be licensed under:
   * [MIT](https://opensource.org/licenses/MIT)
 
 If you need to use a license which isn't in the [IP Policy],
-you will need to obtain permission from the Board to do so. Please [open an issue in the CPC repo](https://github.com/openjs-foundation/cross-project-council/issues), and assign it to brianwarner.
+you will need to obtain permission from the Board to do so.
+Please [open an issue in the CPC repository][new cpc issue],
+and assign it to @brianwarner.
 
 ### 2. Copyright notices
 
@@ -57,27 +59,29 @@ as this simply reflects the merged status of the organizations._
 
 All project websites need to have a [standard website footer][].
 
-### 4. Contributor License Agreement (CLA)
+### 4. Adopting the DCO or a CLA
 
-By default the OpenJS Foundation uses the [DCO][], which means contributors
-submit their contributions under the project's designated open source license.
-Every commit must contain a Signed-off-by line in the commit message (e.g.,
-`Signed-off-by: Authorname <author@email.com>`), indicating the author has the
-right to make the contribution under the open source license.
+Each project much adopt either the [Developer Certificate of Origin (DCO)](DCO)
+or Contributor License Agreement (CLA).
 
-Alternately, projects may decide to adopt a CLA. In this case each contributor
-must be covered by a signed CLA, either as an individual contributor on their
-own behalf or from their employer. The OpenJS Foundation Board of Directors has
-pre-approved an [Individual CLA][ICLA] and a [Corporate CLA][CCLA] which
-projects can adopt without any further review. The decision to adopt a CLA is
-left to each project's governing body.
+The Board has pre-approved an [Individual CLA (ICLA)][ICLA]
+and a [Corporate CLA (CCLA)][CCLA]
+which projects can adopt without any further review.
 
-When a contributor signs the default OpenJS Foundation CLA in one project, they
-will automatically be covered for any other project which uses the same CLA.
+If you need to use a different CLA, you will need to
+[require an exemption from the board](#requiring-an-exemption-from-the-board).
 
-To use the CLA with your project, or if there are special circumstances that
-may require a different CLA, please contact
-[legal-questions@lists.openjsf.org](mailto:legal-questions@lists.openjsf.org).
+To setup the CLA infrastructure, [reach out to the foundation staff](#getting-help).
+
+## Requiring an exemption from the Board
+
+If your project requires an exemption from the [IP Policy][],
+you will need to obtain special permission from the Board.
+To do so, please [open an issue in the Cross Project Council repository](https://github.com/openjs-foundation/cross-project-council/issues/new?title=Board%20exemption%20request%20for),
+and assign or @-mention [@brianwarner](https://github.com/brianwarner) and 
+[your Project Represenatives](https://github.com/openjs-foundation/cross-project-council#impact-project-representatives) if your are an Impact project,
+the [Growth & At Large Project Representatives](https://github.com/openjs-foundation/cross-project-council#growth--at-large-project-representatives)  if your are a Growth or At Large project,
+or [your Champion](https://github.com/openjs-foundation/cross-project-council/blob/master/PROJECT_PROGRESSION.md#application-champion) if you are an Incubating project.
 
 ## Getting help
 
@@ -88,3 +92,5 @@ If you have a question about this policy or how to implement it, please reach ou
 [ICLA]: https://individual-cla.openjsf.org
 [CCLA]: https://corporate-cla.openjsf.org
 [standard website footer]: https://github.com/openjs-foundation/artwork#copyright-notices-for-project-website-footers
+
+

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -61,7 +61,7 @@ All project websites need to have a [standard website footer][].
 
 ### 4. Adopting the DCO or a CLA
 
-Each project much adopt either the [Developer Certificate of Origin (DCO)](DCO)
+Each project much adopt either the [Developer Certificate of Origin (DCO)][DCO]
 or Contributor License Agreement (CLA).
 
 The Board has pre-approved an [Individual CLA (ICLA)][ICLA]
@@ -92,5 +92,4 @@ If you have a question about this policy or how to implement it, please reach ou
 [ICLA]: https://individual-cla.openjsf.org
 [CCLA]: https://corporate-cla.openjsf.org
 [standard website footer]: https://github.com/openjs-foundation/artwork#copyright-notices-for-project-website-footers
-
 

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -62,7 +62,7 @@ All project websites need to have a [standard website footer][].
 ### 4. Adopting the DCO or a CLA
 
 Each project much adopt either the [Developer Certificate of Origin (DCO)][DCO]
-or Contributor License Agreement (CLA).
+or a Contributor License Agreement (CLA).
 
 The Board has pre-approved an [Individual CLA (ICLA)][ICLA]
 and a [Corporate CLA (CCLA)][CCLA]
@@ -92,4 +92,3 @@ If you have a question about this policy or how to implement it, please reach ou
 [ICLA]: https://individual-cla.openjsf.org
 [CCLA]: https://corporate-cla.openjsf.org
 [standard website footer]: https://github.com/openjs-foundation/artwork#copyright-notices-for-project-website-footers
-

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -29,7 +29,7 @@ Documentation may be licensed under:
   * [CC BY 4.0](http://creativecommons.org/licenses/by/4.0/)
   * [MIT](https://opensource.org/licenses/MIT)
 
-If you need to use a license which isn't in the [IP Policy],
+If you need to use a license which isn't in the [IP Policy][],
 you will need to obtain permission from the Board to do so.
 Please [open an issue in the CPC repository][new cpc issue],
 and assign it to @brianwarner.

--- a/IP_POLICY_GUIDANCE.md
+++ b/IP_POLICY_GUIDANCE.md
@@ -30,7 +30,7 @@ Documentation may be licensed under:
   * [MIT](https://opensource.org/licenses/MIT)
 
 If you need to use a license which isn't in the [IP Policy],
-you will need to obtain permission from the Board to do so.
+you will need to obtain permission from the Board to do so. Please [open an issue in the CPC repo](https://github.com/openjs-foundation/cross-project-council/issues), and assign it to brianwarner.
 
 ### 2. Copyright notices
 
@@ -47,7 +47,7 @@ and variations on the (c) symbol.
 
 _Please note that you **must not** change or remove existing copyright lines
 unless you put them there **and** have the right to do so.
-If there are existing copyright lines just
+If there are existing copyright lines
 add the recommended copyright statement below the existing copyright lines.
 You may however update copyright lines that say
 "JS Foundation" or "Node.js Foundation" to "OpenJS Foundation"


### PR DESCRIPTION
The goal of this IP Policy guidance is to make it really simple for projects to comply with the Foundation's IP Policy.

This document is non-exhaustive by design. It is meant to address the most common scenarios, not every corner-case.

It is also opinionated: it favors community norms and best practices in areas where the Foundation's IP Policy provides leeway to do so.

This document is based on prior work from CNCF, available here: https://github.com/cncf/foundation/blob/master/copyright-notices.md, an earlier pull request by @brianwarner, available here: https://github.com/openjs-foundation/cross-project-council/pull/414, and community input.

Co-authored-by: Brian Warner <brian@bdwarner.com>

