### PR TITLE
License preference, per discussion with legal

### DIFF
--- a/proposals/stage-2/COLLABORATION_NETWORK/COLLABORATION_SPACE_PROGRESSION.md
+++ b/proposals/stage-2/COLLABORATION_NETWORK/COLLABORATION_SPACE_PROGRESSION.md
@@ -73,7 +73,7 @@ The Application Champion is a member of the CPC or Foundation staff who commits 
 ##### Initial fit checklist
 
 1. Are the existing members/space leaders agreed to managing the space under open governance?
-1. Have the existing members/space leaders agreed that all work will happen under the [OpenJS Foundation IP Policy](https://ip-policy.openjsf.org)?
+1. Have the existing members/space leaders agreed that all work will happen under the [OpenJS Foundation IP Policy](https://ip-policy.openjsf.org)? Where possible, it is the Foundation's preference that new work/artifacts be licensed Apache 2.0.
 1. Have the existing members/space leaders agreed that the collaboration space will adopt the [OpenJS CoC](https://code-of-conduct.openjsf.org)?
 1. Are licences for any existing material that will be added to the collaboration space repo compatible with Foundation requirements?
 1. Fit with OpenJS Foundation (not all of these need to be met, but provide different ways of assessing strategic fit).

--- a/proposals/stage-2/COLLABORATION_NETWORK/COLLABORATION_SPACE_PROGRESSION.md
+++ b/proposals/stage-2/COLLABORATION_NETWORK/COLLABORATION_SPACE_PROGRESSION.md
@@ -73,7 +73,7 @@ The Application Champion is a member of the CPC or Foundation staff who commits 
 ##### Initial fit checklist
 
 1. Are the existing members/space leaders agreed to managing the space under open governance?
-1. Have the existing members/space leaders agreed that all work will happen under the [OpenJS Foundation IP Policy](https://ip-policy.openjsf.org)? The IP policy permits projects to use a variety of licenses, including MIT, BSD-2, BSD-3, and Apache 2.0. Where there is no preference otherwise, the Foundation recommends that new work/artifacts be licensed Apache 2.0.
+1. Have the existing members/space leaders agreed that all work will happen under the [OpenJS Foundation IP Policy](https://ip-policy.openjsf.org)? The IP policy permits projects to use a variety of licenses, including MIT, BSD-2, BSD-3, and Apache 2.0. Where there is no preference otherwise, the Foundation recommends that new work/artifacts be licensed Apache 2.0 due to its explicitly defined rights and responsibilities.
 1. Have the existing members/space leaders agreed that the collaboration space will adopt the [OpenJS CoC](https://code-of-conduct.openjsf.org)?
 1. Are licences for any existing material that will be added to the collaboration space repo compatible with Foundation requirements?
 1. Fit with OpenJS Foundation (not all of these need to be met, but provide different ways of assessing strategic fit).

--- a/proposals/stage-2/COLLABORATION_NETWORK/COLLABORATION_SPACE_PROGRESSION.md
+++ b/proposals/stage-2/COLLABORATION_NETWORK/COLLABORATION_SPACE_PROGRESSION.md
@@ -73,7 +73,7 @@ The Application Champion is a member of the CPC or Foundation staff who commits 
 ##### Initial fit checklist
 
 1. Are the existing members/space leaders agreed to managing the space under open governance?
-1. Have the existing members/space leaders agreed that all work will happen under the [OpenJS Foundation IP Policy](https://ip-policy.openjsf.org)? Where possible, it is the Foundation's preference that new work/artifacts be licensed Apache 2.0.
+1. Have the existing members/space leaders agreed that all work will happen under the [OpenJS Foundation IP Policy](https://ip-policy.openjsf.org)? The IP policy permits projects to use a variety of licenses, including MIT, BSD-2, BSD-3, and Apache 2.0. Where there is no preference otherwise, the Foundation recommends that new work/artifacts be licensed Apache 2.0.
 1. Have the existing members/space leaders agreed that the collaboration space will adopt the [OpenJS CoC](https://code-of-conduct.openjsf.org)?
 1. Are licences for any existing material that will be added to the collaboration space repo compatible with Foundation requirements?
 1. Fit with OpenJS Foundation (not all of these need to be met, but provide different ways of assessing strategic fit).


### PR DESCRIPTION
From a discussion on the Board, I checked with OpenJS Foundation legal counsel on the preferred license, all other things being equal. While we have a number of options in the IP policy, Apache 2.0 seems to be the preferred option if there are no other reasons to choose something else.

Signed-off-by: Brian Warner <brian@bdwarner.com>