### PR TITLE
Add Marcin Hoppe as a regular member of the CPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Anyone who has been active in the foundation or one of its member projects, as d
 - Jordan Harband ([@ljharb](https://github.com/ljharb))
 - Jory Burson ([@jorydotcom](https://github.com/jorydotcom))
 - Kris Borchers ([@kborchers](https://github.com/kborchers))
+- Marcin Hoppe ([@MarcinHoppe](https://github.com/MarcinHoppe))
 - Mary Marchini ([@mmarchini](https://github.com/mmarchini)
 - Michael Dawson ([@mhdawson](https://github.com/mhdawson))
 - Myles Borins ([@MylesBorins](https://github.com/MylesBorins))


### PR DESCRIPTION
I would like to nominate myself as a regular member of the CPC.

I am an active member of the [Node.js Ecosystem Security WG](https://github.com/nodejs/security-wg).

I also lead the [Vulnerability Disclosures WG](https://github.com/ossf/wg-vulnerability-disclosures) of the [Open Source Security Foundation](https://openssf.org/) and I would like to act as a liaison between the OpenJSF and the OpenSSF (both operating under the Linux Foundation).