### PR TITLE
Allow trivial fixes to the charter

### DIFF
--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -23,6 +23,10 @@ the OpenJS Foundation charter at any time, though the Board will not interfere
 with day-to-day discussions, votes or meetings
 of the CPC.
 
+The above notwithstanding, the CPC may make trivial changes to the charter
+without requiring board approval, including spelling and punctuation fixes,
+so long as they do not change the meaning of the text.
+
 ## Section 3. Board’s Role in Setting OpenJS Foundation’s Strategic Direction.
 
 The Board will set the overall CPC Policy. The policy will describe the


### PR DESCRIPTION
Trivial changes, such as spelling or formatting updates, likely do not need board approval so long
as they do not change the overall interpretation of the CPC Charter. This change would allow the CPC
to make such trivial changes without waiting on board appproval.

Signed-off-by: Brian Warner <brian@bdwarner.com>