### PR TITLE
doc: move MylesBorins to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,14 @@ Anyone who has been active in the foundation or one of its member projects, as d
 - Marcin Hoppe ([@MarcinHoppe](https://github.com/MarcinHoppe))
 - Matteo Collina ([@mcollina](https://github.com/mcollina)
 - Michael Dawson ([@mhdawson](https://github.com/mhdawson))
-- Myles Borins ([@MylesBorins](https://github.com/MylesBorins))
 - Nick O'Leary ([@knolleary](https://github.com/knolleary))
 - Sara Chipps ([@sarajo](https://github.com/sarajo))
 - Sendil Kumar ([@sendilkumarn](https://github.com/sendilkumarn))
 - Waleed Ashraf ([@waleedashraf](https://github.com/waleedashraf))
+
+### Regular Member emeriti
+
+- Myles Borins ([@MylesBorins](https://github.com/MylesBorins))
 
 ### Observers
 


### PR DESCRIPTION
Life and work has thrown a bunch of new challenges and expectations my way and I unfortunately don't have the
time to keep up with the commitments required of a regular member. It is pretty amazing that the foundation and
the CPC are in a place where I feel 100% confident in stepping back.

I'll still be around and thanks to our egalitarian governance I'll still be able to participate in all the meetings 🎉

I've moved myself to emeritus, a new section, something we've done over at Node.js that I quite like. I think
it is nice to keep track of former members.

What a wild ride this has been!