### PR TITLE
doc: add README.md file to /TRAVEL_FUND

### DIFF
--- a/TRAVEL_FUND/README.md
+++ b/TRAVEL_FUND/README.md
@@ -1,0 +1,3 @@
+# Travel Fund
+
+For details on the Travel Fund, please see [MEMBER_TRAVEL_FUND.md](https://github.com/openjs-foundation/cross-project-council/blob/main/project-resources/MEMBER_TRAVEL_FUND.md).


### PR DESCRIPTION
adds a README to the travel fund directory. PR'ing this in because I consistently try to go to this directory and actually mean to go to the file that's linked.