### PR TITLE
ci(automation): add dead link checking

### DIFF
--- a/.github/workflows/dead-link-checker.yml
+++ b/.github/workflows/dead-link-checker.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches:
+      - $default-branch
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+name: Dead Link Checker
+jobs:
+  linkinator:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JustinBeckwith/linkinator-action@v1
+        with:
+          paths: "**/*.md"
+          markdown: true
+          retry: true


### PR DESCRIPTION
At the request of @jorydotcom, adds a CI job that will run on pushes, on a few PR events, and when manually triggered via the GitHub Actions UI.

Historically, in Node.js there's been a non-trivial amount of link rot. This should help us identify dead links and where links will break when we're making changes.