### PR TITLE
Updates per CoC Working Group Meetings

### DIFF
--- a/conduct/HANDLING_CODE_OF_CONDUCT_REPORTS.md
+++ b/conduct/HANDLING_CODE_OF_CONDUCT_REPORTS.md
@@ -43,7 +43,7 @@ When a report is received to `report@openjsf.org` the following actions will be 
    * The staff representative will seek to determine whether the report is emergent and requires immediate attention (e.g. for an ongoing issue) or the report is a reactive response to an incident with no immediate danger. 
 
    * The Staff Representative will identify two contact persons from its CoC Panel to examine and act on the report. The contact persons will be chosen on the basis of schedule and availability.
-   * The contact persons will then execute the following procedures::
+   * The contact persons will then execute the following procedures:
      1. Acknowledging the report: The contact persons will respond to let the reporter or target know that the report is being discussed.
      1. Information gathering: The contact persons will collect information in the private moderation repository..
      1. Discussing the report: The contact persons will discuss the facts of the report in context of opinions via meeting, email, or discussion via private issue.

--- a/conduct/HANDLING_CODE_OF_CONDUCT_REPORTS.md
+++ b/conduct/HANDLING_CODE_OF_CONDUCT_REPORTS.md
@@ -15,57 +15,38 @@ Generally, reports to coc-escalation should refer to a report that was already s
 If a report to coc-esclation does not include one of those, the reporter will be asked to to provide one of those three as the
 reason for reporting to coc-escalation.
 
+All members of the [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS md#code-of-conduct-panel) are subscribed to the report@openjsf.org mailing list.
+The current list of members is documented in ./CODE_OF_CONDUCT_PANEL_MEMERS.md.
+
 ## Code of Conduct
 
-The OpenJS Foundation and its member projects use the Contributor Covenant v2.0 as its Code of Conduct. Refer to the [Code of Conduct](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CODE_OF_CONDUCT.md) for the full text of the CoC and the reporting and esclation procedures.
+The OpenJS Foundation and its member projects use the Contributor Covenant v2.0 as its Code of Conduct. Refer to the [Code of Conduct](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CODE_OF_CONDUCT.md) for the full text of the CoC and the reporting and escalation procedures.
 
 ## Confidentiality and record-keeping
 Personal information is confidential. All reports should be recorded, together with the discussion of it. The following private repos will be used to record and discuss reports.
 
 * report@openjsf.org -> github.com/openjs-foundation/moderation
-* coc-escalation@openjsf.org -> github.com/openjs-foundation/coc-escalation
+
 
 For each report there should be an issue which captures the report, discussion and final conclusion. The report should NOT contain identifying details of the reporter.
 
 ## Conflict of Interest
 
-Any member of the CPC or Code of Conduct Panel(CoCP) who is involved in the report should recuse themselves from the discussions.
+Any member of the CPC or Code of Conduct Panel (CoCP) who is involved in the report should recuse themselves from the discussions.
 
 ## Reports to report@openjsf.org
 
 Note: We understand that the reporter and the target can be separate persons. In this case the CPC will communicate with the reporter unless the target gives permission for the CPC to communicate with them.
 
-All members of the CPC are subscribed to the `report@openjsf.org` mailing list. When a report is received the following actions will be taken:
-   * One of the CPC members will respond to the reporter or target confirming that the report has been received. When possible the same person who responds initially will act as the point of contact for future conversations.
-   * If no response has been sent by the next CPC meeting, the CPC chair will ensure there is a private session in which one of the CPC members is identified as the point of contact.
-   * The point of contact will then ensure the following steps are completed:
-     1. Report is acknowledged: The contact person responds to let the reporter or target know that the report is being discussed.
-     1. Information gathering: Time is allocated to collect information in one place to make sure everyone involved has access.
-     1. Information is discussed: The facts are discussed in context of opinions. This can be done in the issue for the report, or in a meeting in which case the key discussion points should then be added to the issue.
-     1. An action to be taken is arrived at: The action to be taken is decided by consensus as per the standard CPC
-        [Decision Making](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#section-9-decision-making) process.
-     1. Resolution shared: The resolution is shared with the reporter or target by the contact person. If the reporter or target expresses concerns then the contact person will bring these back to the CPC members for further discussion. This cycle can continue until the CPC members reach consensus that the reporter or target's concerns have been adquately addressed. If no feedback is received within 7 days the resolution is considered as accepted.
-     1. Final resolution: the resolution agreed by the CPC members is implemented and the outcome reported to the reporter or target by the main contact.
+When a report is received to `report@openjsf.org` the following actions will be taken:
+   * An OpenJS Foundation staff representative will respond within 24 hours to the reporter or target confirming that the report has been received. 
+   * The staff representative will seek to determine whether the report is emergent and requires immediate attention (e.g. for an ongoing issue) or the report is a reactive response to an incident with no immediate danger. 
 
-## Reports to coc-escalation@openjsf.org
-
-Note: We understand that the reporter and the target can be separate persons. In this case the CPC will communicate with the reporter unless the target gives permission for the CPC to communicate with them.
-
-All members of the [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel)
-are subscribed to the coc-escalation@openjsf.org mailing list. The current list of members is documented in ./CODE_OF_CONDUCT_PANEL_MEMERS.md.
-
-When a report is received the following actions will be taken:
-
-  * One of the Code of Conduct Panel (CoCP) members will respond to the reporter or target confirming that the report has been received. When possible the same person who responds initially will act as the point of contact for future conversations.
-  * If no response has been sent within 1 day the Foundation Executive Director will ensure a member of the Code of Conduct
-    Panel is identified as the main point of contact either through email or scheduling a meeting for the CoCP.
-  * The main point of contact will then ensure the following steps are completed:
-     1. Report is acknowledged: The contact person responds to let the reporter or target know that the report is being discussed.
-     1. Information gathering: Time is allocated to collect information in one place to make sure all CoCP members have access.
-     1. Information is discussed: The facts are discussed in context of opinions. This can be done in the issue for the report, or in a meeting in which case the key discussion points should then be added to the issue.
-     1. An action to be taken is arrived at: The action to be taken is decided by consensus as per the standard CPC
-        [Decision Making](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#section-9-decision-making) process substituting in CoCP for references to the CPC.
-     1. The proposed action is discussed with the leadership for the space to which the report applies (ex CPC or member
-        project leadership). If the leadership representatives expresses concerns then the contact person will bring these back to the CoCP members for further discussion. This cycle can continue until the CoCP members reach consensus that the leadership representatives concerns have been adequately addressed.
-     1. Resolution shared: The resolution is shared with the reporter or target by the contact person. If the reporter or target expresses concerns then the contact person will bring these back to the CPC members for further discussion. This cycle can continue until the CPC members reach consensus that the reporter or target's concerns have been adquately addressed. If no feedback is received within 7 days the resolution is considered as accepted.
-     1. Final resolution: the resolution agreed by the CoCP members is implemented and the outcome reported back to the reporter or target bythe main contact.
+   * The Staff Representative will identify two contact persons from its CoC Panel to examine and act on the report. The contact persons will be chosen on the basis of schedule and availability.
+   * The contact persons will then execute the following procedures::
+     1. Acknowledging the report: The contact persons will respond to let the reporter or target know that the report is being discussed.
+     1. Information gathering: The contact persons will collect information in the private moderation repository..
+     1. Discussing the report: The contact persons will discuss the facts of the report in context of opinions via meeting, email, or discussion via private issue.
+     1. Acting on the report: The contact persons will attempt to reach consensus on the action to be taken.
+     1. Sharing the resolution: If the contact persons are in agreement, the resolution is shared with the reporter or target by the contact persons and recorded in the moderation repository. If the contact persons are not in agreement or if the reporter or target expresses concern or dissatisfaction with the resolution,  then the contact persons will bring the report to the CoC Panel  for further discussion. This cycle can continue until the panel reaches consensus that the reporter or target's concerns have been adequately addressed. If the panel cannot reach consensus within 7 days, the matter will be taken to a vote of the panelists. If no feedback is received within 7 days the resolution is considered as accepted. 
+     1. Final resolution: the resolution is implemented and the outcome reported to the reporter or target, and/or other involved parties.


### PR DESCRIPTION
Related to #726 & Others - 

REVISIONS:
* Removes references to coc-escalation@ & separate process for coc-escalation - everything handled via ‘reports@’
* Clarifies that reports go to a CoC Panel, not the entire CPC
* Designates Staff responsibility for first contact to reporter/ensuring contact persons are identified
* Reinforces use of the /moderation repo
* Creates Contact persons team to handle report processing by an available subset of CoC Panel members
* Creates escalation to full CoC Panel if contact persons are not in agreement OR the resolution is not satisfactory to the reporter/target

COMMENTS (ported from the doc):

general, non-line specific comment
> The one thing that I'm not sure if it will be a deterrent for people is.
> 1) I send a report to report@openjsf.org
> 2) I'm unhappy with the result and want to escalate
> 3) hmm, I need to send the escalation to the same people who already decided in a way that I did not agree with. Will this result in -> why bother its the same group so how is that an escalation?
> It was one of the reasons for escalation to be separate from the regular flow in the earlier version.
> Not a blocking comment, but seems to me that it might deter escalations.

Additional comments ported to specific lines
