### PR TITLE
Travel fund request: Unicode Conference, 13-16 October

### DIFF
--- a/TRAVEL_FUND/2020.md
+++ b/TRAVEL_FUND/2020.md
@@ -1,4 +1,0 @@
-# 2020 Member Travel Fund Record
-
-First Name | Last Name | Event | Reason | Trip Report | Location | Travel Dates | Amount Requested: | Pull Request date | Pull Request link | Date Expense report sent | Amount of Expense Report | Date Sent to Finance | Date approved through Bill.com | Bill.com Amount approved for reimbursement
--|-|-|-|-|-|-|-|-|-|-|-|-|-|-

--- a/TRAVEL_FUND/2021.md
+++ b/TRAVEL_FUND/2021.md
@@ -2,3 +2,4 @@
 
 First Name | Last Name | Event | Reason | Trip Report | Location | Travel Dates | Amount Requested | Pull Request date | Pull Request link | Date Expense report sent | Amount of Expense Report | Date Sent to Finance | Date approved through Bill.com | Bill.com Amount approved for reimbursement
 -|-|-|-|-|-|-|-|-|-|-|-|-|-|-
+Eemeli | Aro | Internationalization & Unicode Conference 45 | Speaker || Santa Clara, CA | 13 - 16 Oct 2021 | 800 USD | 21 Sep 2021 | https://github.com/openjs-foundation/cross-project-council/issues/800 |

--- a/TRAVEL_FUND/2021.md
+++ b/TRAVEL_FUND/2021.md
@@ -1,0 +1,4 @@
+# 2021 Member Travel Fund Record
+
+First Name | Last Name | Event | Reason | Trip Report | Location | Travel Dates | Amount Requested | Pull Request date | Pull Request link | Date Expense report sent | Amount of Expense Report | Date Sent to Finance | Date approved through Bill.com | Bill.com Amount approved for reimbursement
+-|-|-|-|-|-|-|-|-|-|-|-|-|-|-

--- a/project-resources/MEMBER_TRAVEL_FUND.md
+++ b/project-resources/MEMBER_TRAVEL_FUND.md
@@ -5,7 +5,7 @@
 To establish and administer a fund for members of the OpenJS Foundation to travel
 and spread knowledge about and support the Javascript ecosystem and the Foundation.
 
-### [Current Year Fund](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/TRAVEL_FUND/2020.md)
+### [Current Year Fund](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/TRAVEL_FUND/2021.md)
 
 ### [2019 funds](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/TRAVEL_FUND/Achived_Travel_Fund_Records/2019.md)
 


### PR DESCRIPTION
This is a travel fund request for participating at this year's Internationalization & Unicode Conference, and speaking there about the work being done in the Unicode MessageFormat Working Group.

I am the Foundation's representative to that working group, and a maintainer of the `messageformat` project. I have attempted to have my travel costs covered by my employer, but this is not currently possible due to their travel policy not supporting travel outside my home country (Finland).

I'm asking for 800 USD, which is an estimate of the cost of my flights (Chicago -> San Francisco -> Helsinki) and transits to and from airports. I have already made other arrangements covering my ticket for the conference, for accommodations while there, and for travel up to Chicago; this would be an extension of a personal trip.

Edit: Forgot to add earlier the @openjs-foundation/cpc mention.