### PR TITLE
chore: add cron to link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -4,6 +4,8 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
 name: Link Checker
 jobs:


### PR DESCRIPTION
adds a cron to the link checker that runs it nightly so we can spot issues before they're a problem in PRs