### PR TITLE
Update Governance links from HEAD to main

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -231,15 +231,15 @@ The pull request may be fast-tracked if two CPC members approve the fast-trackin
 CPC members may request fast-tracking of pull requests they did not author. In that case only, the request itself is also one fast-track approval. Upvote the comment anyway to avoid any doubt.
 
 [cpc repo]: https://github.com/openjs-foundation/cross-project-council
-[cpc charter]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md
-[cpc charter term]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#voting-members
-[CPC charter section 5]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#section-5-responsibilities-and-expectations-of-the-cpc
+[cpc charter]: https://github.com/openjs-foundation/cross-project-council/blob/main/CPC-CHARTER.md
+[cpc charter term]: https://github.com/openjs-foundation/cross-project-council/blob/main/CPC-CHARTER.md#voting-members
+[CPC charter section 5]: https://github.com/openjs-foundation/cross-project-council/blob/main/CPC-CHARTER.md#section-5-responsibilities-and-expectations-of-the-cpc
 [cpc regular members team]: https://github.com/orgs/openjs-foundation/teams/cpc-regular-members
 [README]: ./README.md
-[OpenJS Foundation Directory]: https://github.com/openjs-foundation/directory-private/blob/HEAD/cpc-private.md
+[OpenJS Foundation Directory]: https://github.com/openjs-foundation/directory-private/blob/main/cpc-private.md
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Active OpenJS Collaborator]: #definition-of-an-active-openjs-collaborator
-[OpenJS Foundation CPC directory]: https://github.com/openjs-foundation/directory-private/blob/HEAD/groups/cross-project-council.yml
+[OpenJS Foundation CPC directory]: https://github.com/openjs-foundation/directory-private/blob/main/groups/cross-project-council.yml
 [Primary CPC Director]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#the-primary-cpc-director-as-defined-in-43d-in-the-openjs-foundation-bylaws
 [Secondary CPC Director]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#the-secondary-cpc-director-as-defined-in-43e-in-theopenjs-foundation-bylaws
 [Tertiary CPC Director]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#the-tertiary-cpc-director-as-defined-in-43f-in-the-openjs-foundation-bylaws

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -231,9 +231,9 @@ The pull request may be fast-tracked if two CPC members approve the fast-trackin
 CPC members may request fast-tracking of pull requests they did not author. In that case only, the request itself is also one fast-track approval. Upvote the comment anyway to avoid any doubt.
 
 [cpc repo]: https://github.com/openjs-foundation/cross-project-council
-[cpc charter]: https://github.com/openjs-foundation/cross-project-council/blob/main/CPC-CHARTER.md
-[cpc charter term]: https://github.com/openjs-foundation/cross-project-council/blob/main/CPC-CHARTER.md#voting-members
-[CPC charter section 5]: https://github.com/openjs-foundation/cross-project-council/blob/main/CPC-CHARTER.md#section-5-responsibilities-and-expectations-of-the-cpc
+[cpc charter]: ./CPC-CHARTER.md
+[cpc charter term]: ./CPC-CHARTER.md#voting-members
+[CPC charter section 5]: ./CPC-CHARTER.md#section-5-responsibilities-and-expectations-of-the-cpc
 [cpc regular members team]: https://github.com/orgs/openjs-foundation/teams/cpc-regular-members
 [README]: ./README.md
 [OpenJS Foundation Directory]: https://github.com/openjs-foundation/directory-private/blob/main/cpc-private.md


### PR DESCRIPTION
I am finding that when I click on a link and then want to edit that file, I am viewing it at a commit rather than on the main branch. This makes it so that the file appears uneditable. You simply need to switch to the main branch and then can edit but it may be confusing to folks.