### PR TITLE
Remove Node.js Security WG template

### DIFF
--- a/PROJECT_SECURITY_REPORTING.md
+++ b/PROJECT_SECURITY_REPORTING.md
@@ -6,8 +6,6 @@ Each OpenJS Foundation project must publish a security policy in an easily acces
 
 Projects that have their own organization on GitHub are advised to place the `SECURITY.md` file in the `.github` repository for the organization.
 
-The [Node.js Ecosystem Security WG Template](https://github.com/nodejs/security-wg/blob/HEAD/processes/responsible_disclosure_template.md) can be used by projects that do not have their own security reporting infrastructure.
-
 ## Reporting
 
 Project security policy should explain how to confidentially report a security vulnerability.


### PR DESCRIPTION
This template was removed in this pull request:
https://github.com/nodejs/security-wg/pull/789/files

I dont know if we should provide our own template or how we want to mitigate this change, but for now, this is breaking the linkinator in PRs.