### PR TITLE
meta: add VoltrexMaster as a regular member

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Anyone who has been active in the foundation or one of its member projects, as d
 - Matteo Collina ([@mcollina](https://github.com/mcollina))
 - Michael Dawson ([@mhdawson](https://github.com/mhdawson))
 - Mike Samuel ([@mikesamuel](https://github.com/mikesamuel))
+- Mohammed Keyvanzadeh ([@VoltrexMaster](https://github.com/VoltrexMaster))
 - Nick O'Leary ([@knolleary](https://github.com/knolleary))
 - Parris Lucas ([@GrooveCS](https://github.com/groovecs))
 - Sara Chipps ([@sarajo](https://github.com/sarajo))


### PR DESCRIPTION
I would like to nominate myself as a regular member.

I've been an active member of the [Node.js organization](https://github.com/nodejs) for about a year now and been helping to maintain Node.js, triaging and helping users/contributors and reviewing to help things land.

I would like to participate and lend a hand to CPC and it's future.