### PR TITLE
Fix link checker using live rather than build URLs for validating

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -19,3 +19,5 @@ jobs:
           markdown: true
           retry: true
           linksToSkip: "https://github.com/openjs-foundation/directory-private"
+          urlRewriteSearch: "https://github.com/openjs-foundation/cross-project-council/blob/HEAD/"
+          urlRewriteReplace: ""


### PR DESCRIPTION
Fixes #858

The link checker was working as it should, however it was not fully configured.
Links which started with the full URL `https://github.com/openjs-foundation/cross-project-council/blob/HEAD/` would check that live URL, rather than looking at the state of the build being tested.

This is fixed by configuring a URL rewrite to simply remove that starting segment of the URL.
It then looks for markdown files from the root directory.

The link checker check will fail as it highlights (correctly) some broken links.
These can be fixed with another PR.

You can validate this change locally using https://github.com/nektos/act if you so wish.