### PR TITLE
Fix broken links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/regular-member-pull-request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/regular-member-pull-request.md
@@ -7,11 +7,11 @@ about: You'd like to participate in the Cross Project Council's work as a Regula
 We are thrilled that you'd like to participate in our work in a meaningful way as a Regular Member of the Cross Project Council.
 
 Requirements and rules around becoming a Regular Member can be found in our Governance:
-https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GOVERNANCE.md#approving-and-onboarding-regular-members
+https://github.com/openjs-foundation/cross-project-council/blob/HEAD/governance/GOVERNANCE.md#approving-and-onboarding-regular-members
 
 Please fill out information below.
 
 Thanks!
 -->
 
-Please describe your recent participation in the work of the foundation or its member projects as described in the [CPC Governance requirements for becoming a Regular Member](https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GOVERNANCE.md#approving-and-onboarding-regular-members)
+Please describe your recent participation in the work of the foundation or its member projects as described in the [CPC Governance requirements for becoming a Regular Member](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/governance/GOVERNANCE.md#approving-and-onboarding-regular-members)

--- a/.github/PULL_REQUEST_TEMPLATE/regular-member-pull-request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/regular-member-pull-request.md
@@ -7,11 +7,11 @@ about: You'd like to participate in the Cross Project Council's work as a Regula
 We are thrilled that you'd like to participate in our work in a meaningful way as a Regular Member of the Cross Project Council.
 
 Requirements and rules around becoming a Regular Member can be found in our Governance:
-https://github.com/openjs-foundation/cross-project-council/blob/HEAD/GOVERNANCE.md#approving-and-onboarding-regular-members
+https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GOVERNANCE.md#approving-and-onboarding-regular-members
 
 Please fill out information below.
 
 Thanks!
 -->
 
-Please describe your recent participation in the work of the foundation or its member projects as described in the [CPC Governance requirements for becoming a Regular Member](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/GOVERNANCE.md#approving-and-onboarding-regular-members)
+Please describe your recent participation in the work of the foundation or its member projects as described in the [CPC Governance requirements for becoming a Regular Member](https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GOVERNANCE.md#approving-and-onboarding-regular-members)

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -18,6 +18,6 @@ jobs:
           paths: "**/*.md"
           markdown: true
           retry: true
-          linksToSkip: "https://github.com/openjs-foundation/directory-private"
+          linksToSkip: "https://github.com/openjs-foundation/directory-private, https://twitter.com/*"
           urlRewriteSearch: "https://github.com/openjs-foundation/cross-project-council/blob/HEAD/"
           urlRewriteReplace: ""

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -32,14 +32,14 @@ For reporting issues in spaces managed by the OpenJS Foundation, for example, re
 
 ## Escalate an issue
 
-The OpenJS Foundation maintains a [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled.
+The OpenJS Foundation maintains a [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled.
 
 In order to escalate to the CoCP, email <coc-escalation@lists.openjsf.org>.
 
 ## More Info
 
 For more information, refer to the full
-[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
+[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -32,14 +32,14 @@ For reporting issues in spaces managed by the OpenJS Foundation, for example, re
 
 ## Escalate an issue
 
-The OpenJS Foundation maintains a [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled.
+The OpenJS Foundation maintains a [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled.
 
 In order to escalate to the CoCP, email <coc-escalation@lists.openjsf.org>.
 
 ## More Info
 
 For more information, refer to the full
-[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
+[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
 
 ---
 

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -334,5 +334,5 @@ policies.
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Condorcet]: http://en.wikipedia.org/wiki/Condorcet_method
 [Single Transferable Vote]: http://en.wikipedia.org/wiki/Single_transferable_vote
-[Active OpenJS Collaborator]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/GOVERNANCE.md#definition-of-an-active-openjs-collaborator
+[Active OpenJS Collaborator]: https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GOVERNANCE.md#definition-of-an-active-openjs-collaborator
 [OpenJS Foundation bylaws]: https://bylaws.openjsf.org/

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -334,5 +334,5 @@ policies.
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Condorcet]: http://en.wikipedia.org/wiki/Condorcet_method
 [Single Transferable Vote]: http://en.wikipedia.org/wiki/Single_transferable_vote
-[Active OpenJS Collaborator]: https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GOVERNANCE.md#definition-of-an-active-openjs-collaborator
+[Active OpenJS Collaborator]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/governance/GOVERNANCE.md#definition-of-an-active-openjs-collaborator
 [OpenJS Foundation bylaws]: https://bylaws.openjsf.org/

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -103,11 +103,11 @@ This is an informational checklist to help projects onboard into the OpenJS Foun
 - [ ] Update project CoC reporting methods to include OpenJS Foundation escalation path
 - [ ] List official domains that the project commits to transfer to the OpenJS Foundation following graduation
 - [ ] Identify and document other core project infrastructure
-- [ ] Adopt either the [Contributor License Agreement (CLA) or the Developer Certificate of Origin (DCO)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/IP_POLICY_GUIDANCE.md#4-adopting-the-dco-or-a-cla)
+- [ ] Adopt either the [Contributor License Agreement (CLA) or the Developer Certificate of Origin (DCO)](https://github.com/openjs-foundation/cross-project-council/blob/main/governance/IP_POLICY_GUIDANCE.md#4-adopting-the-dco-or-a-cla)
 - [ ] Add or Update Governance.md document (required for Impact stage)
 - [ ] Confirm required files in place (CODE_OF_CONDUCT.md, LICENSE.md)
 - [ ] Publish Project Charter on website or GitHub (see [charter template](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/PROJECT_CHARTER_TEMPLATE.md))
-- [ ] Update [legal copyright notice](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/IP_POLICY_GUIDANCE.md#2-copyright-notices) on GitHub
+- [ ] Update [legal copyright notice](https://github.com/openjs-foundation/cross-project-council/blob/main/governance/IP_POLICY_GUIDANCE.md#2-copyright-notices) on GitHub
 - [ ] Add [copyright notices for project website footers](https://github.com/openjs-foundation/artwork#copyright-notices-for-project-website-footers) to project website
 - [ ] Add [OpenJS Foundation logo](https://github.com/openjs-foundation/artwork#openjs-foundation-logos) to project website
 - [ ] [Add Project logo](https://github.com/openjs-foundation/artwork#preparing-artwork-for-contribution) to OpenJS Foundation website

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -103,11 +103,11 @@ This is an informational checklist to help projects onboard into the OpenJS Foun
 - [ ] Update project CoC reporting methods to include OpenJS Foundation escalation path
 - [ ] List official domains that the project commits to transfer to the OpenJS Foundation following graduation
 - [ ] Identify and document other core project infrastructure
-- [ ] Adopt either the [Contributor License Agreement (CLA) or the Developer Certificate of Origin (DCO)](https://github.com/openjs-foundation/cross-project-council/blob/main/governance/IP_POLICY_GUIDANCE.md#4-adopting-the-dco-or-a-cla)
+- [ ] Adopt either the [Contributor License Agreement (CLA) or the Developer Certificate of Origin (DCO)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/governance/IP_POLICY_GUIDANCE.md#4-adopting-the-dco-or-a-cla)
 - [ ] Add or Update Governance.md document (required for Impact stage)
 - [ ] Confirm required files in place (CODE_OF_CONDUCT.md, LICENSE.md)
 - [ ] Publish Project Charter on website or GitHub (see [charter template](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/PROJECT_CHARTER_TEMPLATE.md))
-- [ ] Update [legal copyright notice](https://github.com/openjs-foundation/cross-project-council/blob/main/governance/IP_POLICY_GUIDANCE.md#2-copyright-notices) on GitHub
+- [ ] Update [legal copyright notice](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/governance/IP_POLICY_GUIDANCE.md#2-copyright-notices) on GitHub
 - [ ] Add [copyright notices for project website footers](https://github.com/openjs-foundation/artwork#copyright-notices-for-project-website-footers) to project website
 - [ ] Add [OpenJS Foundation logo](https://github.com/openjs-foundation/artwork#openjs-foundation-logos) to project website
 - [ ] [Add Project logo](https://github.com/openjs-foundation/artwork#preparing-artwork-for-contribution) to OpenJS Foundation website

--- a/conduct/HANDLING_CODE_OF_CONDUCT_REPORTS.md
+++ b/conduct/HANDLING_CODE_OF_CONDUCT_REPORTS.md
@@ -1,7 +1,7 @@
 # Handling reports and escalation
 This document describes the proposed process for handling reports and escalation, along with relevant roles in the OpenJS Foundation.
 
-This process covers two types of reports based on the [Foundation's Code of Conduct Requirements](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md):
+This process covers two types of reports based on the [Foundation's Code of Conduct Requirements](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md):
 
 * Reports for spaces managed by the Cross Project Council (CPC) which come in through `report@opensjsf.org`
 * Escalations which come in through `coc-escalation@openjsf.org`.
@@ -51,7 +51,7 @@ All members of the CPC are subscribed to the `report@openjsf.org` mailing list. 
 
 Note: We understand that the reporter and the target can be separate persons. In this case the CPC will communicate with the reporter unless the target gives permission for the CPC to communicate with them.
 
-All members of the [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel)
+All members of the [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel)
 are subscribed to the coc-escalation@openjsf.org mailing list. The current list of members is documented in ./CODE_OF_CONDUCT_PANEL_MEMERS.md.
 
 When a report is received the following actions will be taken:

--- a/conduct/HANDLING_CODE_OF_CONDUCT_REPORTS.md
+++ b/conduct/HANDLING_CODE_OF_CONDUCT_REPORTS.md
@@ -1,7 +1,7 @@
 # Handling reports and escalation
 This document describes the proposed process for handling reports and escalation, along with relevant roles in the OpenJS Foundation.
 
-This process covers two types of reports based on the [Foundation's Code of Conduct Requirements](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md):
+This process covers two types of reports based on the [Foundation's Code of Conduct Requirements](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md):
 
 * Reports for spaces managed by the Cross Project Council (CPC) which come in through `report@opensjsf.org`
 * Escalations which come in through `coc-escalation@openjsf.org`.
@@ -51,7 +51,7 @@ All members of the CPC are subscribed to the `report@openjsf.org` mailing list. 
 
 Note: We understand that the reporter and the target can be separate persons. In this case the CPC will communicate with the reporter unless the target gives permission for the CPC to communicate with them.
 
-All members of the [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel)
+All members of the [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel)
 are subscribed to the coc-escalation@openjsf.org mailing list. The current list of members is documented in ./CODE_OF_CONDUCT_PANEL_MEMERS.md.
 
 When a report is received the following actions will be taken:

--- a/governance/GOVERNANCE.md
+++ b/governance/GOVERNANCE.md
@@ -236,10 +236,10 @@ CPC members may request fast-tracking of pull requests they did not author. In t
 [CPC charter section 5]: ../CPC-CHARTER.md#section-5-responsibilities-and-expectations-of-the-cpc
 [cpc regular members team]: https://github.com/orgs/openjs-foundation/teams/cpc-regular-members
 [README]: ../README.md
-[OpenJS Foundation Directory]: https://github.com/openjs-foundation/directory-private/blob/main/cpc-private.md
+[OpenJS Foundation Directory]: https://github.com/openjs-foundation/directory-private/blob/HEAD/cpc-private.md
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Active OpenJS Collaborator]: #definition-of-an-active-openjs-collaborator
-[OpenJS Foundation CPC directory]: https://github.com/openjs-foundation/directory-private/blob/main/groups/cross-project-council.yml
+[OpenJS Foundation CPC directory]: https://github.com/openjs-foundation/directory-private/blob/HEAD/groups/cross-project-council.yml
 [Primary CPC Director]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#the-primary-cpc-director-as-defined-in-43d-in-the-openjs-foundation-bylaws
 [Secondary CPC Director]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#the-secondary-cpc-director-as-defined-in-43e-in-theopenjs-foundation-bylaws
 [Tertiary CPC Director]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#the-tertiary-cpc-director-as-defined-in-43f-in-the-openjs-foundation-bylaws

--- a/governance/WORKING_GROUPS.md
+++ b/governance/WORKING_GROUPS.md
@@ -139,7 +139,7 @@ The purpose of the Code of Conduct Working Group is to define and maintain a set
 Responsibilities include:
 
 * Define and maintain overarching Code of Conduct and moderation processes, documentation and resources as they pertain to the Foundation and the Cross Project Council.
-* Provide guidance/resources to implement the minimum Code of Conduct and moderation requirements for projects as part of Foundation membership as defined in the [Foundation Code of Conduct Requirements](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
+* Provide guidance/resources to implement the minimum Code of Conduct and moderation requirements for projects as part of Foundation membership as defined in the [Foundation Code of Conduct Requirements](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
 * Define and maintain template Code of Conduct and moderation processes and documentation as resources for the Foundation’s projects to use in whole or as guidance to develop their own processes, documentation, and resources, including training materials
 * Define and maintain Code of Conduct and moderation processes on handling violations within Foundation and its teams and groups (excluding Foundation projects).
 * Define and maintain Code of Conduct and moderation processes on handling escalations from Foundation projects, including communication

--- a/governance/WORKING_GROUPS.md
+++ b/governance/WORKING_GROUPS.md
@@ -139,7 +139,7 @@ The purpose of the Code of Conduct Working Group is to define and maintain a set
 Responsibilities include:
 
 * Define and maintain overarching Code of Conduct and moderation processes, documentation and resources as they pertain to the Foundation and the Cross Project Council.
-* Provide guidance/resources to implement the minimum Code of Conduct and moderation requirements for projects as part of Foundation membership as defined in the [Foundation Code of Conduct Requirements](https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
+* Provide guidance/resources to implement the minimum Code of Conduct and moderation requirements for projects as part of Foundation membership as defined in the [Foundation Code of Conduct Requirements](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
 * Define and maintain template Code of Conduct and moderation processes and documentation as resources for the Foundation’s projects to use in whole or as guidance to develop their own processes, documentation, and resources, including training materials
 * Define and maintain Code of Conduct and moderation processes on handling violations within Foundation and its teams and groups (excluding Foundation projects).
 * Define and maintain Code of Conduct and moderation processes on handling escalations from Foundation projects, including communication

--- a/governance/transfer-repo-into-org.md
+++ b/governance/transfer-repo-into-org.md
@@ -41,6 +41,6 @@ See [GitHub's documentation on transferring repos][] on how to perform the neces
 
 
 [GitHub's documentation on transferring repos]: https://help.github.com/articles/about-repository-transfers/
-[OpenJS Foundation GitHub Organization Management Policy]: https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GITHUB_ORG_MANAGEMENT_POLICY.md
+[OpenJS Foundation GitHub Organization Management Policy]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/governance/GITHUB_ORG_MANAGEMENT_POLICY.md
 [the contributing guide]: https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
 [the issue tracker of the Cross Project Council repository]: https://github.com/openjs-foundation/cross-project-council/issues

--- a/governance/transfer-repo-into-org.md
+++ b/governance/transfer-repo-into-org.md
@@ -41,6 +41,6 @@ See [GitHub's documentation on transferring repos][] on how to perform the neces
 
 
 [GitHub's documentation on transferring repos]: https://help.github.com/articles/about-repository-transfers/
-[OpenJS Foundation GitHub Organization Management Policy]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/GITHUB_ORG_MANGEMENT_POLICY.md
+[OpenJS Foundation GitHub Organization Management Policy]: https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GITHUB_ORG_MANAGEMENT_POLICY.md
 [the contributing guide]: https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
 [the issue tracker of the Cross Project Council repository]: https://github.com/openjs-foundation/cross-project-council/issues

--- a/meetings/2019/2019-04-01.md
+++ b/meetings/2019/2019-04-01.md
@@ -29,7 +29,7 @@ Extracted from **bootstrap-agenda** labelled issues and pull requests from the *
 
 * [BW] Infrastructure: Mailing lists  (5 min) [#134](https://github.com/openjs-foundation/bootstrap/issues/134)
   * What do we want to create comms-wise, what do we specifically not want to create?
-  * From: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md we’d need coc-escalation@xxx.org and report@xxxx.org
+  * From: https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md we’d need coc-escalation@xxx.org and report@xxxx.org
  
   * Discussion around if we should qualify cpc with ‘internal’ or ‘private’. Consensus
      seems to be private. Sarah in CNCF they use toc-private and toc-public.

--- a/meetings/2019/2019-04-01.md
+++ b/meetings/2019/2019-04-01.md
@@ -29,7 +29,7 @@ Extracted from **bootstrap-agenda** labelled issues and pull requests from the *
 
 * [BW] Infrastructure: Mailing lists  (5 min) [#134](https://github.com/openjs-foundation/bootstrap/issues/134)
   * What do we want to create comms-wise, what do we specifically not want to create?
-  * From: https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md we’d need coc-escalation@xxx.org and report@xxxx.org
+  * From: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md we’d need coc-escalation@xxx.org and report@xxxx.org
  
   * Discussion around if we should qualify cpc with ‘internal’ or ‘private’. Consensus
      seems to be private. Sarah in CNCF they use toc-private and toc-public.

--- a/meetings/2020/2020-09-29.md
+++ b/meetings/2020/2020-09-29.md
@@ -45,7 +45,7 @@
   * No license in the repo right now?
   * Possibly MIT but unclear.
   * Can we relicense CC?
-  * MIT is OK for documentation (see https://github.com/openjs-foundation/cross-project-council/blob/main/governance/IP_POLICY_GUIDANCE.md#1-licensing
+  * MIT is OK for documentation (see https://github.com/openjs-foundation/cross-project-council/blob/HEAD/governance/IP_POLICY_GUIDANCE.md#1-licensing
   * There’s a license in the repo, so we are all set. Closing. 
 
 * Should we have a lightweight mechanism to spin off ad hoc CPC working groups? [#649](https://github.com/openjs-foundation/cross-project-council/issues/649)

--- a/meetings/2020/2020-09-29.md
+++ b/meetings/2020/2020-09-29.md
@@ -45,7 +45,7 @@
   * No license in the repo right now?
   * Possibly MIT but unclear.
   * Can we relicense CC?
-  * MIT is OK for documentation (see https://github.com/openjs-foundation/cross-project-council/blob/HEAD/IP_POLICY_GUIDANCE.md#1-licensing
+  * MIT is OK for documentation (see https://github.com/openjs-foundation/cross-project-council/blob/main/governance/IP_POLICY_GUIDANCE.md#1-licensing
   * There’s a license in the repo, so we are all set. Closing. 
 
 * Should we have a lightweight mechanism to spin off ad hoc CPC working groups? [#649](https://github.com/openjs-foundation/cross-project-council/issues/649)

--- a/meetings/2020/2020-12-15.md
+++ b/meetings/2020/2020-12-15.md
@@ -40,7 +40,7 @@
 * Prepare to open nominations for 2nd Board seat [#687](https://github.com/openjs-foundation/cross-project-council/issues/687)
  * one seat is up for election early in new year (CPC representative)
  * open call for nominees the first meeting of 2021
- * This describes the expectations - https://github.com/openjs-foundation/cross-project-council/blob/main/governance/COMMUNITY_BOARD_SEAT_EXPECTATIONS.md
+ * This describes the expectations - https://github.com/openjs-foundation/cross-project-council/blob/HEAD/governance/COMMUNITY_BOARD_SEAT_EXPECTATIONS.md
 
 * Move CPC meetings to bi-weekly cadence [#680](https://github.com/openjs-foundation/cross-project-council/issues/680)
   * Suggestion to create a pinned yearly issue inspired from AMP’s Advisory Committee’s https://github.com/ampproject/meta-ac/issues/101

--- a/meetings/2020/2020-12-15.md
+++ b/meetings/2020/2020-12-15.md
@@ -40,7 +40,7 @@
 * Prepare to open nominations for 2nd Board seat [#687](https://github.com/openjs-foundation/cross-project-council/issues/687)
  * one seat is up for election early in new year (CPC representative)
  * open call for nominees the first meeting of 2021
- * This describes the expectations - https://github.com/openjs-foundation/cross-project-council/blob/HEAD/COMMUNITY_BOARD_SEAT_EXPECTATIONS.md
+ * This describes the expectations - https://github.com/openjs-foundation/cross-project-council/blob/main/governance/COMMUNITY_BOARD_SEAT_EXPECTATIONS.md
 
 * Move CPC meetings to bi-weekly cadence [#680](https://github.com/openjs-foundation/cross-project-council/issues/680)
   * Suggestion to create a pinned yearly issue inspired from AMP’s Advisory Committee’s https://github.com/ampproject/meta-ac/issues/101

--- a/meetings/2021/2021-05-25.md
+++ b/meetings/2021/2021-05-25.md
@@ -28,7 +28,7 @@
 ### openjs-foundation/cross-project-council
 
 * approve Node.js TSC Charter revisions [#762](https://github.com/openjs-foundation/cross-project-council/issues/762)
-  * Just waiting now for 14 days as required by -https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GOVERNANCE.md#approving-project-charters
+  * Just waiting now for 14 days as required by -https://github.com/openjs-foundation/cross-project-council/blob/HEAD/governance/GOVERNANCE.md#approving-project-charters
   * Please review/comment as would be good to have more +1s
 
 * move `nvm` from Incubating to At-Large [#760](https://github.com/openjs-foundation/cross-project-council/pull/760)

--- a/meetings/2021/2021-05-25.md
+++ b/meetings/2021/2021-05-25.md
@@ -28,7 +28,7 @@
 ### openjs-foundation/cross-project-council
 
 * approve Node.js TSC Charter revisions [#762](https://github.com/openjs-foundation/cross-project-council/issues/762)
-  * Just waiting now for 14 days as required by -https://github.com/openjs-foundation/cross-project-council/blob/HEAD/GOVERNANCE.md#approving-project-charters
+  * Just waiting now for 14 days as required by -https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GOVERNANCE.md#approving-project-charters
   * Please review/comment as would be good to have more +1s
 
 * move `nvm` from Incubating to At-Large [#760](https://github.com/openjs-foundation/cross-project-council/pull/760)

--- a/meetings/2021/2021-07-20.md
+++ b/meetings/2021/2021-07-20.md
@@ -48,7 +48,7 @@ Book club call is upcoming
 * Clarify
 [#778](https://github.com/openjs-foundation/cross-project-council/issues/778)
   * Is having a DCO or CLA required? CPC says yes; Robin or Michael will find the source that sets the requirement. 
-  * Yes as per https://github.com/openjs-foundation/cross-project-council/blob/HEAD/IP_POLICY_GUIDANCE.md
+  * Yes as per https://github.com/openjs-foundation/cross-project-council/blob/main/governance/IP_POLICY_GUIDANCE.md
   * Text of the CLA is the same across projects; exceptions must be cleared by Board
   * OpenJS Foundation has strong preference for certain tools. 
   * Project to upgrade OpenJSF Projects on JSF CLA Bot is slow going but on the books

--- a/meetings/2021/2021-07-20.md
+++ b/meetings/2021/2021-07-20.md
@@ -48,7 +48,7 @@ Book club call is upcoming
 * Clarify
 [#778](https://github.com/openjs-foundation/cross-project-council/issues/778)
   * Is having a DCO or CLA required? CPC says yes; Robin or Michael will find the source that sets the requirement. 
-  * Yes as per https://github.com/openjs-foundation/cross-project-council/blob/main/governance/IP_POLICY_GUIDANCE.md
+  * Yes as per https://github.com/openjs-foundation/cross-project-council/blob/HEAD/governance/IP_POLICY_GUIDANCE.md
   * Text of the CLA is the same across projects; exceptions must be cleared by Board
   * OpenJS Foundation has strong preference for certain tools. 
   * Project to upgrade OpenJSF Projects on JSF CLA Bot is slow going but on the books

--- a/meetings/2021/2021-08-03.md
+++ b/meetings/2021/2021-08-03.md
@@ -49,7 +49,7 @@
 * Clarify whether it is a requirement to use either CLA or DCO at OpenJS Foundation [#778](https://github.com/openjs-foundation/cross-project-council/issues/778)
   * Remaining question is if we should update the IP policy to clarify you have to
     use one or the other?
-  * comment with approach which is: The final discussion was that we'll keep this open. If/when there is some other update to the IP policy then we'll bring up clarifying this point. In the mean time, the guidance doc is pretty clear: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/IP_POLICY_GUIDANCE.md#4-adopting-the-dco-or-a-cla
+  * comment with approach which is: The final discussion was that we'll keep this open. If/when there is some other update to the IP policy then we'll bring up clarifying this point. In the mean time, the guidance doc is pretty clear: https://github.com/openjs-foundation/cross-project-council/blob/main/governance/IP_POLICY_GUIDANCE.md#4-adopting-the-dco-or-a-cla
 
 * CPC Chairperson election 2021 [#772](https://github.com/openjs-foundation/cross-project-council/issues/772)
   * Jory mentioned that she had not received any other nominations

--- a/meetings/2021/2021-08-03.md
+++ b/meetings/2021/2021-08-03.md
@@ -49,7 +49,7 @@
 * Clarify whether it is a requirement to use either CLA or DCO at OpenJS Foundation [#778](https://github.com/openjs-foundation/cross-project-council/issues/778)
   * Remaining question is if we should update the IP policy to clarify you have to
     use one or the other?
-  * comment with approach which is: The final discussion was that we'll keep this open. If/when there is some other update to the IP policy then we'll bring up clarifying this point. In the mean time, the guidance doc is pretty clear: https://github.com/openjs-foundation/cross-project-council/blob/main/governance/IP_POLICY_GUIDANCE.md#4-adopting-the-dco-or-a-cla
+  * comment with approach which is: The final discussion was that we'll keep this open. If/when there is some other update to the IP policy then we'll bring up clarifying this point. In the mean time, the guidance doc is pretty clear: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/governance/IP_POLICY_GUIDANCE.md#4-adopting-the-dco-or-a-cla
 
 * CPC Chairperson election 2021 [#772](https://github.com/openjs-foundation/cross-project-council/issues/772)
   * Jory mentioned that she had not received any other nominations

--- a/meetings/2022/2022-03-15.md
+++ b/meetings/2022/2022-03-15.md
@@ -56,7 +56,7 @@ Next working session is “Repo cleanup”
 ## Dates and Reminders
 
 Please review regularly our list of dates and reminders:
-https://github.com/openjs-foundation/cross-project-council/blob/main/Dates-and-Reminders.md
+https://github.com/openjs-foundation/cross-project-council/blob/HEAD/Dates-and-Reminders.md
 
 ## Q&A, Other
 

--- a/meetings/2022/2022-03-29.md
+++ b/meetings/2022/2022-03-29.md
@@ -54,7 +54,7 @@ Are there any initiatives or agenda items that we should use a working session t
 ## Dates and Reminders
 
 Please review regularly our list of dates and reminders:
-https://github.com/openjs-foundation/cross-project-council/blob/main/Dates-and-Reminders.md
+https://github.com/openjs-foundation/cross-project-council/blob/HEAD/Dates-and-Reminders.md
 
 ## Q&A, Other
 

--- a/proposals/approved/SECURITY_REPORTING/README.md
+++ b/proposals/approved/SECURITY_REPORTING/README.md
@@ -11,7 +11,7 @@ Currently OpenJS Foundation projects do not have consistently documented standar
 
 See also:
 - [Security reporting in OpenJS Foundation projects](https://gist.github.com/MarcinHoppe/b13a870770522c31a8386ada48b2e40f)
-- [Guidelines for responsible reporting and disclosure of security vulnerabilities](https://github.com/nodejs/package-maintenance/blob/main/docs/security-guidelines.md)
+- [Guidelines for responsible reporting and disclosure of security vulnerabilities](https://github.com/nodejs/package-maintenance/blob/HEAD/docs/security-guidelines.md)
 
 ## Required Resources
 

--- a/proposals/incubating/CHARTER_REVIEW/charter_review.md
+++ b/proposals/incubating/CHARTER_REVIEW/charter_review.md
@@ -44,4 +44,4 @@ CPC members should add themselves as reviewers to the associated charter issue. 
 
 Project Charters should be reviewed and approved within two weeks of submission. An exception may be made if the charter is submitted during a holiday period (such as the end of the year) or in the event either the project or CPC has requested legal review. 
 
-Charters are approved when they meet the requirements outlined in the 'Approving Charters' section of [GOVERNANCE.md](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/GOVERNANCE.md#approving-project-charters).
+Charters are approved when they meet the requirements outlined in the 'Approving Charters' section of [GOVERNANCE.md](https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GOVERNANCE.md#approving-project-charters).

--- a/proposals/incubating/CHARTER_REVIEW/charter_review.md
+++ b/proposals/incubating/CHARTER_REVIEW/charter_review.md
@@ -44,4 +44,4 @@ CPC members should add themselves as reviewers to the associated charter issue. 
 
 Project Charters should be reviewed and approved within two weeks of submission. An exception may be made if the charter is submitted during a holiday period (such as the end of the year) or in the event either the project or CPC has requested legal review. 
 
-Charters are approved when they meet the requirements outlined in the 'Approving Charters' section of [GOVERNANCE.md](https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GOVERNANCE.md#approving-project-charters).
+Charters are approved when they meet the requirements outlined in the 'Approving Charters' section of [GOVERNANCE.md](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/governance/GOVERNANCE.md#approving-project-charters).


### PR DESCRIPTION
Links broke probably in this PR https://github.com/openjs-foundation/cross-project-council/pull/841

Twitter status links keeps failing randomly. I have added them to skip.