### PR TITLE
Travel fund request: Eemeli Aro, OpenJS World 2022

### DIFF
--- a/TRAVEL_FUND/2022.md
+++ b/TRAVEL_FUND/2022.md
@@ -5,3 +5,4 @@ First Name | Last Name | Event | Reason | Trip Report | Location | Travel Dates 
 Christian | Bromann | OpenJS World 2022 | Speaker || Austin, TX | 06 - 10 Jun 2022 | 1100 USD | 17 Apr 2022 | tbd |
 Waleed | Ashraf | OpenJS World 2022 | CPC || Austin, TX | 06 - 11 Jun 2022 | 2287 USD | 25 Apr 2022 | tbd |
 Dylan | Schiemann | OpenJS World 2022 | CPC / Activity || Austin, TX | 06 - 10 Jun 2022 | 1782 USD | 25 Apr 2022 | tbd |
+Eemeli | Aro | OpenJS World 2022 | Speaker + CPC || Austin, TX | 06 - 10 Jun 2022 | 1583 USD | 26 Apr 2022 | tbd |


### PR DESCRIPTION
As I have a limited budget for conference trips from my employer, I'm looking for assistance from the OpenJS Foundation for the accommodation costs (5 nights, $1583 with taxes & fees) so that I'll be able to speak on `Intl.MessageFormat` and related topics also at other conferences this year.

This PR includes a commit from PR #865, as that one adds the `TRAVEL_FUND/2022.md` file. I'll be happy to rebase this once that PR or some other adds the file to the repo.