### PR TITLE
Update project infrastructure documentation

### DIFF
--- a/governance/GOVERNANCE.md
+++ b/governance/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # OpenJS Cross Project Council
 
-For the current list of Team members, see the project [README.md][README] and the [OpenJS Foundation Directory][] (restricted access for privacy reasons).
+For the current list of Team members, see the project [README.md][README].
 
 ## Members
 
@@ -157,7 +157,7 @@ Once a PR is ready to be landed, the CPC member who lands the pull request shoul
 
 * Send a notification to the project contacts for the project identified in the PR indicating that a new Regular CPC member has joined the CPC on behalf of the project.
 * Add the member to the github `cpc-regular-members` [team][cpc regular members team]
-* Add the member to the `cpc-private` email list and private directory by opening a PR against the [OpenJS Foundation CPC directory][]
+* Ask the LF to add the member to the `cpc-private` email list
 * Introduce the new member at the next CPC meeting.
 
 _Note: Former Voting members whose terms have just ended will automatically become Regular members, unless they indicate otherwise._
@@ -230,10 +230,8 @@ CPC members may request fast-tracking of pull requests they did not author. In t
 [CPC charter section 5]: ../CPC-CHARTER.md#section-5-responsibilities-and-expectations-of-the-cpc
 [cpc regular members team]: https://github.com/orgs/openjs-foundation/teams/cpc-regular-members
 [README]: ../README.md
-[OpenJS Foundation Directory]: https://github.com/openjs-foundation/directory-private/blob/HEAD/cpc-private.md
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Active OpenJS Collaborator]: #definition-of-an-active-openjs-collaborator
-[OpenJS Foundation CPC directory]: https://github.com/openjs-foundation/directory-private/blob/HEAD/groups/cross-project-council.yml
 [Primary CPC Director]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#the-primary-cpc-director-as-defined-in-43d-in-the-openjs-foundation-bylaws
 [Secondary CPC Director]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#the-secondary-cpc-director-as-defined-in-43e-in-theopenjs-foundation-bylaws
 [Tertiary CPC Director]: https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CPC-CHARTER.md#the-tertiary-cpc-director-as-defined-in-43f-in-the-openjs-foundation-bylaws

--- a/project-resources/INFRASTRUCTURE_MENU.md
+++ b/project-resources/INFRASTRUCTURE_MENU.md
@@ -3,12 +3,15 @@
 The OpenJS Foundation provides a number of services to support critical infrastructure for hosted projects. We expect projects to be respectful of these services, to abide by their terms of use, and to be put into use for the good of the project and the OpenJS Foundation.
 
 ## Billing for services and mitigating the bus factor
-**For all project services, please add an OpenJS Foundation account at an owner or highest-level of permission access.**  This helps ensure continuity by reducing the bus factor on the project, and ensures you are never locked out. It is also **required** in order for the OpenJS Foundation to pay service fees on behalf of your project. Access to the OpenJS Foundation administrator/owner account will never be shared with others, and will only be granted to operations, IT, and finance staff at the Linux Foundation.
+**For all project services, please add an OpenJS or Linux Foundation account at an owner or highest-level of permission access.**  This helps ensure continuity by reducing the bus factor on the project, and ensures you are never locked out.  It is also **required** in order for the OpenJS Foundation to pay service fees on behalf of your project.  Access to the OpenJS Foundation administrator/owner account will never be shared with others, and will only be granted to operations, IT, and finance staff at the Linux Foundation.
 
 If you don’t know the name of the OpenJS Foundation account for a service, please contact operations@openjsf.org.
 
 ## Websites
-Digital Ocean offers free droplets to OpenJS Foundation projects. Projects are solely responsible for the content and design of their websites.
+Digital Ocean offers free droplets to OpenJS Foundation projects, or projects can use GitHub Pages for free.  Projects are solely responsible for the content and design of their websites.
+
+Resources and base themes (please contribute other templates as you find them):
+* The [Amethyst theme](https://github.com/qunitjs/jekyll-theme-amethyst) is maintained by @krinkle for use with GitHub Pages.
 
 ## Servers
 Additional servers needed to run scripts, bots, or other project applications may also be deployed on Digital Ocean. These resources are generously provided by Digital Ocean for free, so please be respectful of the arrangement and do not deploy overly intensive workloads such as CI/CD without discussion with the Foundation. Additional servers can be procured on behalf of the project pending request and budget approval.
@@ -19,10 +22,10 @@ The OpenJS Foundation will register and manage each project’s primary domain, 
 The OpenJS Foundation can either manage your DNS for you, or delegate to one of your own nameservers. This is often required if you use a CDN (see below).
 
 ## SSL Certificates
-The OpenJS Foundation will purchase 2-year wildcard SSL certs for each project's managed domains as needed.
+The OpenJS Foundation will purchase 2-year wildcard SSL certs for each project's managed domains if Let's Encrypt is not an appropriate solution.
 
 ## Source Control
-By default all OpenJS Foundation projects have open source repositories in their own GitHub Organizations. The OpenJS Foundation admin account must be added as administrator for each repository. Two-factor authentication must be required for everyone in the organization.
+By default all OpenJS Foundation projects have open source repositories in their own GitHub Organizations.  The `thelinuxfoundation` admin account must be added as owner for each organization.  Two-factor authentication must be required for everyone in the organization.
 
 ## Build (CI/CD)
 Projects which require CI/CD should attempt to use solutions which are free to open source projects. Non-free options may be requested, subject to budget approval.
@@ -33,10 +36,13 @@ Projects with a technical need for a CDN should attempt to use no-cost services 
 ## Website Monitoring
 The OpenJS Foundation can provide website downtime and performance monitoring through StatusCake or Pingdom.
 
+## Security scanning
+The Linux Foundation offers scanning through [LFX Security](https://lfx.linuxfoundation.org/tools/security/). There is no cost for this service.
+
 ## Open Source Dependency Monitoring (FOSSA)
 
 ## Credential Storage
-The OpenJS Foundation can provide credential storage and sharing through LastPass Enterprise. Because the credentials are shared through a LastPass Enterprise account, each user only needs a free account to receive them. Managed credentials may include:
+The OpenJS Foundation can provide credential storage and sharing. Because the credentials are shared through a LastPass Enterprise account, each user only needs a free account to receive them.  Managed credentials may include:
 
 * Usernames / Passwords
 * Secret keys
@@ -46,14 +52,14 @@ The OpenJS Foundation can provide credential storage and sharing through LastPas
 The OpenJS Foundation uses Groups.io for mailing lists on the openjsf.org domain. All projects are welcome to request their own lists on the @lists.openjsf.org subdomain.
 
 ## Slack
-Projects are welcome to create channels on the OpenJS Foundation Slack (https://openjs-foundation.slack.com), or set up their own free Slack workspace.
+Projects are welcome to create channels on the [OpenJS Foundation Slack](https://openjs-foundation.slack.com), or set up their own free Slack workspace.
 
 ## Zoom
-Projects may request that standing meetings be added to the OpenJS Foundation calendar. The OpenJS Foundation currently has two Zoom Pro meeting accounts, and one Zoom Webinar account which is capable of livestreaming. Please be mindful of conflicts with other projects by requesting your meeting be scheduled on the shared calendar via email to operations@openjsf.org.  
+Projects may request that standing meetings be added to the [OpenJS Foundation calendar](https://calendar.openjsf.org).  The OpenJS Foundation currently has multiple Zoom accounts capable of livestreaming.  Please be mindful of conflicts with other projects by requesting your meeting be scheduled on the shared calendar via email to operations@openjsf.org.   
 
-All OpenJS Foundation Zoom accounts can host up to 300 participants, and meetings can be recorded as an .mp4 for posting to a project’s YouTube channel.
+All OpenJS Foundation Zoom accounts can host up to 500 participants, and meetings can be recorded as an .mp4 for posting to a project’s YouTube channel.
 
-Impact projects and At Large projects with an approved Growth Plan can request a dedicated Zoom Pro account. Projects may also request a Webinar license for livestreaming, but please be aware it is a significant expense and is subject to budget approval.
+Impact projects and At Large projects with an approved Growth Plan can request a dedicated Zoom account.
 
 ## Other services
 We recognize that some projects may have needs not addressed by the above list. For no-cost services, please let us know what you’re using at operations@openjsf.org so that we can add the service to our inventory. For services with a fee, please reach out to operations@openjsf.org to coordinate a proposal and budget request.


### PR DESCRIPTION
This commit removes references to the Directory generator, which has been deprecated. The LF now
has a centrally maintained tool that does this for us.

There are also a few other changes to the project tooling guidance that have occurred over the past
few years, and the documentation had gotten a little stale. This commit includes updates where
appropriate.

Signed-off-by: Brian Warner <brian@bdwarner.com>