### PR TITLE
meta: add @achrinza as a Regular Member

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Anyone who has been active in the foundation or one of its member projects, as d
 - Mohammed Keyvanzadeh ([@VoltrexMaster](https://github.com/VoltrexMaster))
 - Nick O'Leary ([@knolleary](https://github.com/knolleary))
 - Parris Lucas ([@GrooveCS](https://github.com/groovecs))
+- Rifa Achrinza ([@achrinza](https://github.com/achrinza))
 - Sara Chipps ([@sarajo](https://github.com/sarajo))
 - Sendil Kumar ([@sendilkumarn](https://github.com/sendilkumarn))
 - Waleed Ashraf ([@waleedashraf](https://github.com/waleedashraf))


### PR DESCRIPTION
This is a self-nomination of Rifa Achrinza as an OpenJS Foundation
(OpenJSF) Cross Project Council (CPC) Regular Member.

I have been an active member of the [LoopBack](https://loopback.io)
Technical Steering Committee (TSC), and have helped in bringing
LoopBack towards formalising a distributed, open governance model.

I've started attending the OpenJSF CPC meetings and reviewing the CPC
work and their relation to LoopBack.

With LoopBack's on-boarding as a hosted, At-Large Project under the
OpenJSF, I'd like to extend my participation be more involved in
supporting the work of the OpenJSF CPC, such as those around
supporting the projects' security posture and compliance.

see: https://github.com/loopbackio/loopback-governance/issues/26
Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>