### PR TITLE
Add Ian Sutherland to 2022 travel fund

### DIFF
--- a/TRAVEL_FUND/2022.md
+++ b/TRAVEL_FUND/2022.md
@@ -9,3 +9,4 @@ Eemeli | Aro | OpenJS World 2022 | Speaker + CPC || Austin, TX | 06 - 10 Jun 202
 Tierney | Cyren | OpenJS World 2022 | Project Member + CPC || Austin, TX | 06 - 10 Jun 2022 | 1535 USD | 26 Apr 2022 | tbd |
 Hemanth | HM | OpenJS World 2022 | Speaker || Austin, TX | 06 - 10 Jun 2022 | 1500 USD | 24 May 2022 | tbd |
 Nick | O'Leary | OpenJS World 2022 | Speaker (Maintainer Showcase) || Austin, TX | 06 - 10 Jun 2022 | 2000 USD | 12 May 2022 | tbd |
+Sutherland | Ian | OpenJS World 2022 | Project Member || Austin, TX | 06 - 10 Jun 2022 | 2494 USD | 13 May 2022 | tbd |


### PR DESCRIPTION
Making a travel fund request for OpenJS World 2022 to attend the conference and collaborator summit. I am hoping to help facilitate the Tooling Group sessions at the collab summit. I am also speaking at the event but virtually.

**Costs**
Hotel: Aloft Downtown Austin $1,999.44 USD
Flight: $626.25 CAD ($494.44 USD) https://www.google.com/travel/flights/s/karjSxt737ityLFk7