### PR TITLE
chore: add Hemanth HM to 2022 travel fund

### DIFF
--- a/TRAVEL_FUND/2022.md
+++ b/TRAVEL_FUND/2022.md
@@ -7,3 +7,4 @@ Waleed | Ashraf | OpenJS World 2022 | CPC || Austin, TX | 06 - 11 Jun 2022 | 228
 Dylan | Schiemann | OpenJS World 2022 | CPC / Activity || Austin, TX | 06 - 10 Jun 2022 | 1782 USD | 25 Apr 2022 | tbd |
 Eemeli | Aro | OpenJS World 2022 | Speaker + CPC || Austin, TX | 06 - 10 Jun 2022 | 1583 USD | 26 Apr 2022 | tbd |
 Tierney | Cyren | OpenJS World 2022 | Project Member + CPC || Austin, TX | 06 - 10 Jun 2022 | 1535 USD | 26 Apr 2022 | tbd |
+Hemanth | HM | OpenJS World 2022 | Speaker || Austin, TX | 06 - 10 Jun 2022 | 1500 USD | 24 May 2022 | tbd |


### PR DESCRIPTION
Sorry for the late PR, there were some challenges with the travel fund and hence this PR is happening now. 

- Name of the event : OpenJS World 2022
- The location, dates of the event and where you will be travelling from: Austin, TX June 6-10 is the event, I shall be traveling from SF.
- The presentation you intend to give: [Standards workshop](https://sched.co/10fNK)
- The size of the stipend you wish to receive:  1500 USD.
- Estimate: 593 (Airbnb) + 753 (flight) + 154 (transport)

//cc @openjs-foundation/cpc

Signed-off-by: hemanth.hm <hemanth.hm@gmail.com>