### PR TITLE
Add Lea Verou - TAG meeting July 2022 to travel fund

### DIFF
--- a/TRAVEL_FUND/2022.md
+++ b/TRAVEL_FUND/2022.md
@@ -10,3 +10,4 @@ Tierney | Cyren | OpenJS World 2022 | Project Member + CPC || Austin, TX | 06 - 
 Hemanth | HM | OpenJS World 2022 | Speaker || Austin, TX | 06 - 10 Jun 2022 | 1500 USD | 24 May 2022 | tbd |
 Nick | O'Leary | OpenJS World 2022 | Speaker (Maintainer Showcase) || Austin, TX | 06 - 10 Jun 2022 | 2000 USD | 12 May 2022 | tbd |
 Sutherland | Ian | OpenJS World 2022 | Project Member || Austin, TX | 06 - 10 Jun 2022 | 2494 USD | 13 May 2022 | tbd |
+Lea | Verou | TAG meeting | TAG member || London, UK | 25 - 28 Jul 2022 | 1800 USD | 10 Jul 2022 | tbd


### PR DESCRIPTION
Hello,

[OpenJS Foundation has kindly agreed to cover half of my TAG travel when they nominated me in Dec 2020](https://www.w3.org/2020/12/07-tag-nominations#lv=) but Robin said I still need to follow the PR process this time, for transparency so here it is 😄 This is the second f2f TAG meeting during my term, the previous four were virtual.

Meeting dates are [July 25-28](https://github.com/w3ctag/meetings/tree/gh-pages/2022/07-London) (in 2 weeks). Because flight costs are insane right now, I cut costs by arriving on the day of the meeting and leaving on the evening of the last day instead of arriving a day before and leaving the day after.

The total trip will cost approx. $3,568, so I'm requesting **$1800** for OpenJS' half. Bocoup will cover the rest.