### PR TITLE
chore: fix broken links

### DIFF
--- a/meetings/2020/2020-02-18.md
+++ b/meetings/2020/2020-02-18.md
@@ -55,7 +55,7 @@ Joe: Can probably close this issue now, there’s been enough progress.
 Michael: We do need someone to champion phase two – extensions of the MVP. That’s the only thing left to do.
 
 * Populate the Code Of Conduct Panel
-[#469](https://github.com/openjs-foundation/cross-project-council/issues/469)
+[openjs-foundation/code-of-conduct#3](https://github.com/openjs-foundation/code-of-conduct/issues/3)
 
 Michael: We’ve landed the first draft. We need to identify the people who will make up the panel. We need to identify bootstrap members and get the diversity of representatives that we require, and identify who’re going be people who make up the COCP moving forward.
 

--- a/meetings/2020/2020-02-25.md
+++ b/meetings/2020/2020-02-25.md
@@ -59,7 +59,7 @@
 
 ### openjs-foundation/cross-project-council
 
-* Populate the Code Of Conduct Panel [#469](https://github.com/openjs-foundation/cross-project-council/issues/469)
+* Populate the Code Of Conduct Panel [openjs-foundation/code-of-conduct#3](https://github.com/openjs-foundation/code-of-conduct/issues/3)
 
 * Discussion around next steps
 * Robin asking marketing committee for rep and reaching out to projects for reps as well

--- a/meetings/2020/2020-03-03.md
+++ b/meetings/2020/2020-03-03.md
@@ -75,7 +75,7 @@ Michael: I think these are independant issues anyway, they shouldn’t block any
 
 Joe: I’ve now got action items for moving forward voting stuff! 🎉
 
-* Populate the Code Of Conduct Panel [#469](https://github.com/openjs-foundation/cross-project-council/issues/469)
+* Populate the Code Of Conduct Panel [openjs-foundation/code-of-conduct#3](https://github.com/openjs-foundation/code-of-conduct/issues/3)
 
 Robin: We’re still looking for people to self-nominate. If you represent projects on this call, please reach out to me and Brian for people you’d like to nominate, and we can reach out to them directly via email.
 

--- a/meetings/2020/2020-03-10.md
+++ b/meetings/2020/2020-03-10.md
@@ -64,7 +64,7 @@
 https://github.com/openjs-foundation/cross-project-council/issues/488
 
 
-* Populate the Code Of Conduct Panel [#469](https://github.com/openjs-foundation/cross-project-council/issues/469)
+* Populate the Code Of Conduct Panel [openjs-foundation/code-of-conduct#3](https://github.com/openjs-foundation/code-of-conduct/issues/3)
   * Robin, looking for self nominations, not much interest yet. Going to start
      reaching out to people.
   * Joe will try to reach out to some spaces in the Node.js community as well.

--- a/meetings/2020/2020-03-17.md
+++ b/meetings/2020/2020-03-17.md
@@ -61,7 +61,7 @@
 * OpenJS Collaboration Network ? [#474](https://github.com/openjs-foundation/cross-project-council/issues/474)
   * Working on PR, should submit in next day or 2.
 
-* Populate the Code Of Conduct Panel [#469](https://github.com/openjs-foundation/cross-project-council/issues/469)
+* Populate the Code Of Conduct Panel [openjs-foundation/code-of-conduct#3](https://github.com/openjs-foundation/code-of-conduct/issues/3)
   * Still working to close on the candidates.
 
 * Add Foundation-wide copyright guidance [#414](https://github.com/openjs-foundation/cross-project-council/pull/414)

--- a/meetings/2020/2020-03-24.md
+++ b/meetings/2020/2020-03-24.md
@@ -65,7 +65,7 @@
 
 * OpenJS Collaboration Network ? [#474](https://github.com/openjs-foundation/cross-project-council/issues/474)
 
-* Populate the Code Of Conduct Panel [#469](https://github.com/openjs-foundation/cross-project-council/issues/469)
+* Populate the Code Of Conduct Panel [openjs-foundation/code-of-conduct#3](https://github.com/openjs-foundation/code-of-conduct/issues/3)
   * Matteo have reached out moderation team in Node.js. Jordan volunteered
     and will be our representative.
   * Robin still doing, outreach, other projects please send you rep.

--- a/meetings/2020/2020-03-31.md
+++ b/meetings/2020/2020-03-31.md
@@ -71,7 +71,7 @@
   * CNCF SIGs were mentioned offline, want to take some time to learn more about those
     to see if we can borrow/re-use what’s there.
 
-* Populate the Code Of Conduct Panel [#469](https://github.com/openjs-foundation/cross-project-council/issues/469)
+* Populate the Code Of Conduct Panel [openjs-foundation/code-of-conduct#3](https://github.com/openjs-foundation/code-of-conduct/issues/3)
    * Continuing to populate
 
 * Add Foundation-wide copyright guidance [#414](https://github.com/openjs-foundation/cross-project-council/pull/414)

--- a/meetings/2020/2020-04-07.md
+++ b/meetings/2020/2020-04-07.md
@@ -48,7 +48,7 @@
   * Once we get the voting members from non-impact projects completed will come back
      to this.
 
-* How do we keep Code of Conduct up to date without upstreaming our modifications to it [#503](https://github.com/openjs-foundation/cross-project-council/issues/503)
+* How do we keep Code of Conduct up to date without upstreaming our modifications to it [openjs-foundation/code-of-conduct#6](https://github.com/openjs-foundation/code-of-conduct/issues/6)
   * Don’t think we can get current PR landed
   * Tobie will give more context in the private section at the end.
   * Discuss more in next week's meeting after that.
@@ -75,7 +75,7 @@
   * Nothing new this week. Michael still want to find time review CNCF SIGs for
     additional context.
 
-* Populate the Code Of Conduct Panel [#469](https://github.com/openjs-foundation/cross-project-council/issues/469)
+* Populate the Code Of Conduct Panel [openjs-foundation/code-of-conduct#3](https://github.com/openjs-foundation/code-of-conduct/issues/3)
   * Added to issue the reps we need to cover and some info on where we
     have made progress.
 

--- a/meetings/2020/2020-04-14.md
+++ b/meetings/2020/2020-04-14.md
@@ -71,7 +71,7 @@ Jory:
 * Responsible security disclosures [#326](https://github.com/openjs-foundation/cross-project-council/issues/326)
   * Nothing new from last week.
 
-* Populate the Code Of Conduct Panel [#469](https://github.com/openjs-foundation/cross-project-council/issues/469)
+* Populate the Code Of Conduct Panel [openjs-foundation/code-of-conduct#3](https://github.com/openjs-foundation/code-of-conduct/issues/3)
   * the foundation has done outreach to add more people to the panel
   * role:
     1. CoC WG of a project requests additional help,

--- a/meetings/2020/2020-04-21.md
+++ b/meetings/2020/2020-04-21.md
@@ -47,12 +47,12 @@
 
 ### openjs-foundation/cross-project-council
 
-* How do we keep Code of Conduct up to date without upstreaming our modifications to it [#503](https://github.com/openjs-foundation/cross-project-council/issues/503)
+* How do we keep Code of Conduct up to date without upstreaming our modifications to it [openjs-foundation/code-of-conduct#6](https://github.com/openjs-foundation/code-of-conduct/issues/6)
   * Would be good to have a working session for this and 469 together.
   * Jory seem to remember that had action to set up doodle, instead worked on 
      org doc to capture the different issues we have.
 
-* Populate the Code Of Conduct Panel [#469](https://github.com/openjs-foundation/cross-project-council/issues/469)
+* Populate the Code Of Conduct Panel [openjs-foundation/code-of-conduct#3](https://github.com/openjs-foundation/code-of-conduct/issues/3)
   * Would be good to have a working session for this and 503 together.
 
 * Updates to requirements of potential new Regular Members [#513](https://github.com/openjs-foundation/cross-project-council/issues/513)

--- a/meetings/2020/2020-05-12.md
+++ b/meetings/2020/2020-05-12.md
@@ -52,7 +52,7 @@
 * Voting members chosen by Regular members [#504](https://github.com/openjs-foundation/cross-project-council/issues/504)
   * vote complete, Michael and Eemeli voted in.
 
-* How do we keep Code of Conduct up to date without upstreaming our modifications to it [#503](https://github.com/openjs-foundation/cross-project-council/issues/503)
+* How do we keep Code of Conduct up to date without upstreaming our modifications to it [openjs-foundation/code-of-conduct#6](https://github.com/openjs-foundation/code-of-conduct/issues/6)
   * Move to CoC repo
   * remove agenda tag.
 
@@ -61,7 +61,7 @@
     * one for charter changes
     * one for proposal and then we’ll try to get it landed as 0 and open PR to move to stage 1
 
-* Populate the Code Of Conduct Panel [#469](https://github.com/openjs-foundation/cross-project-council/issues/469)
+* Populate the Code Of Conduct Panel [openjs-foundation/code-of-conduct#3](https://github.com/openjs-foundation/code-of-conduct/issues/3)
   * move to CoC repo
   * remove agenda tag.
 


### PR DESCRIPTION
fixes a suite of broken links from [this run](https://github.com/openjs-foundation/cross-project-council/runs/7280370508?check_suite_focus=true). Note that the 503-ing links are not doing that, so I assume they're a hiccup.