### PR TITLE
chore: add opensource.org/licenses/ to skip

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -18,6 +18,6 @@ jobs:
           paths: "**/*.md"
           markdown: true
           retry: true
-          linksToSkip: "https://github.com/openjs-foundation/directory-private, https://twitter.com/*"
+          linksToSkip: "https://github.com/openjs-foundation/directory-private, https://twitter.com/*, https://opensource.org/licenses/*"
           urlRewriteSearch: "https://github.com/openjs-foundation/cross-project-council/blob/HEAD/"
           urlRewriteReplace: ""


### PR DESCRIPTION
this PR skips opensource.org/licenses/, which currently returns a 503 100% of the time. I'm not sure if they're just blocking traffic from Actions or what but I've seen zero runs that don't return 503 despite the links fully working for me.