### PR TITLE
meta: update GitHub workflow actions

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -12,7 +12,7 @@ jobs:
   linkinator:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: JustinBeckwith/linkinator-action@v1
         with:
           paths: "**/*.md"

--- a/.github/workflows/linter-workflow.yml
+++ b/.github/workflows/linter-workflow.yml
@@ -8,12 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
-    - name: Use Node.js 12.x
-      uses: actions/setup-node@v1
+    - name: Use Node.js 18.x
+      uses: actions/setup-node@v3
       with:
-        node-version: 12.x
+        node-version: 18
+        check-latest: true
 
     - name: npm install
       run: npm ci


### PR DESCRIPTION
Update the GitHub workflow actions to their latest versions and use the latest Node.js LTS release.