### PR TITLE
build: add patch code of conduct workflow

### DIFF
--- a/.github/workflows/patch-code-of-conduct.yml
+++ b/.github/workflows/patch-code-of-conduct.yml
@@ -1,0 +1,31 @@
+name: Patch CoC
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  patch:
+    runs-on: ubuntu-latest
+    name: Patch
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Patch CoC
+        uses: pkgjs/patch-my-code-of-conduct@v1.2.0
+        with:
+          base_url: '../../conduct/artifacts/CODE_OF_CONDUCT_PATCH.patch'
+          template_url: 'https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md'
+          patch_file_path: './conduct/artifacts/CODE_OF_CONDUCT_PATCH.patch'
+          output_file_path: './CODE_OF_CONDUCT.md'
+      - uses: gr2m/create-or-update-pull-request-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          body: "Applied the patch to the base Code of Conduct."
+          commit-message: 'doc: update Code of Conduct'
+          title: 'doc: update Code of Conduct'

--- a/conduct/artifacts/CODE_OF_CONDUCT_PATCH.patch
+++ b/conduct/artifacts/CODE_OF_CONDUCT_PATCH.patch
@@ -1,0 +1,41 @@
+--- ./coc-expected.md	2023-03-27 17:54:12
++++ ./coc-current.md	2023-03-27 17:53:58
+@@ -43,16 +43,15 @@
+ 
+ ---
+ 
++_Contributor Covenant Code of Conduct v2.0, from [commit 8001bf8](https://github.com/EthicalSource/contributor_covenant/blob/8001bf8c6e7cd2606657e2816710770d8a79b7dc/content/version/2/0/code_of_conduct.md)_
+ 
+-# Contributor Covenant Code of Conduct
+-
+ ## Our Pledge
+ 
+ We as members, contributors, and leaders pledge to make participation in our
+ community a harassment-free experience for everyone, regardless of age, body
+ size, visible or invisible disability, ethnicity, sex characteristics, gender
+ identity and expression, level of experience, education, socio-economic status,
+-nationality, personal appearance, race, caste, color, religion, or sexual
++nationality, personal appearance, race, religion, or sexual
+ identity and orientation.
+ 
+ We pledge to act and interact in ways that contribute to an open, welcoming,
+@@ -106,7 +105,9 @@
+ 
+ Instances of abusive, harassing, or otherwise unacceptable behavior may be
+ reported to the community leaders responsible for enforcement at
+-[INSERT CONTACT METHOD].
++the email addresses listed above in the
++[Reporting](#report-an-issue-in-a-project) and
++[Escalation](#escalate-an-issue) sections.
+ All complaints will be reviewed and investigated promptly and fairly.
+ 
+ All community leaders are obligated to respect the privacy and security of the
+@@ -156,7 +157,7 @@
+ individual, or aggression toward or disparagement of classes of individuals.
+ 
+ **Consequence**: A permanent ban from any sort of public interaction within the
+-community.
++project community.
+ 
+ ## Attribution
+ 


### PR DESCRIPTION
Please be aware that this is highly experimental, and might/will have some bugs. Couple of notes:

- The code, documentation, and tests live inside https://github.com/anonrig/patch-my-code-of-conduct (for now)
- When this pull request is merged, it will automatically open a pull request to update `CODE_OF_CONDUCT.md` file with the `patch` applied. 
- Before merging this pull-request, we need to get aligned with the appropriate patch file.

If we are aligned & happy on this path, I'll be happy to move the project under `openjs-foundation` organization.