### PR TITLE
Add Ben Hutton to regular members list

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Anyone who has been active in the foundation or one of its member projects, as d
 - Abigail Cabunoc Mayes ([@abbycabs](https://github.com/abbycabs))
 - Abraham Jr Agiri ([@codeekage](https://github.com/codeekage))
 - Antón Molleda ([@molant](https://github.com/molant))
+- Ben Hutton ([@relequestual](https://github.com/relequestual))
 - Ben Michel ([@obensource](https://github.com/obensource))
 - Christian Bromann ([@christian-bromann](https://github.com/christian-bromann))
 - Claudio Wunder ([@ovflowd](https://github.com/ovflowd))


### PR DESCRIPTION
I was invited to add myself to the regular members list. I'm the project lead for the JSON Schema org.
I am active in the OpenJS Foundation slack, submitted PRs, and sparked discussions for the CPC. I am here to serve the open source community.

Signed-off-by: Ben Hutton <relequestual@gmail.com>