### PR TITLE
doc: add code of conduct prefix text

### DIFF
--- a/conduct/artifacts/CODE_OF_CONDUCT_PREAMBLE.md
+++ b/conduct/artifacts/CODE_OF_CONDUCT_PREAMBLE.md
@@ -1,6 +1,6 @@
 # Code of Conduct
 
-The OpenJS Foundation and its member projects use [Contributor Covenant v2.0](https://contributor-covenant.org/version/2/0/code_of_conduct) as their code of conduct. The full text is included [below](#contributor-covenant-code-of-conduct-v20) in English, and [translations](https://www.contributor-covenant.org/translations) are available on the Contributor Covenant website.
+The OpenJS Foundation and its member projects use a modified version of the Contributor Covenant as their code of conduct, and the translations from the original script will not reflect all modifications. The full text is included below in English, and [the original translations](https://www.contributor-covenant.org/translations) are available on the Contributor Covenant website.
 
 ## Commitment
 

--- a/conduct/artifacts/CODE_OF_CONDUCT_PREAMBLE.md
+++ b/conduct/artifacts/CODE_OF_CONDUCT_PREAMBLE.md
@@ -1,0 +1,42 @@
+# Code of Conduct
+
+The OpenJS Foundation and its member projects use [Contributor Covenant v2.0](https://contributor-covenant.org/version/2/0/code_of_conduct) as their code of conduct. The full text is included [below](#contributor-covenant-code-of-conduct-v20) in English, and [translations](https://www.contributor-covenant.org/translations) are available on the Contributor Covenant website.
+
+## Commitment
+
+All recipients of reports commit to:
+
+- maintain the confidentiality with regard to the reporter and victim of an incident, and
+- participate in the path for escalation as outlined in the section on Escalation when required.
+
+## Report an issue in a project
+
+1. To report an issue in one of the projects listed below, please use the method provided. The project itself is responsible for managing these reports.
+    * **AMP Project:** <code-of-conduct@amp.dev>
+    * **Appium:** email maintainers
+    * **Electron:** <coc@electronjs.org>
+    * **Express.js:** <express-coc@lists.openjsf.org>
+    * **Fastify:** <hello@matteocollina.com> or <tommydelved@gmail.com>
+    * **HospitalRun:** <hello@hospitalrun.io>
+    * **LoopBack** <tsc@loopback.io>
+    * **Node.js:** <report@nodejs.org>
+    * **Node-RED:** <team@nodered.org>
+    * **Webdriver.io:** [contact TSC reps](https://github.com/webdriverio/webdriverio/blob/HEAD/AUTHORS.md)
+    * **Webhint:** <support@webhint.io>
+2. For every other OpenJS Foundation project, please email <report@lists.openjsf.org>. The Cross Project Council (CPC) is responsible for managing these reports.
+
+
+## Report an issue in a space managed by the foundation
+
+For reporting issues in spaces managed by the OpenJS Foundation, for example, repositories within the OpenJS organization or an live event such as a conferences, email <report@lists.openjsf.org>. The Cross Project Council (CPC) is responsible for managing these reports.
+
+## Escalate an issue
+
+The OpenJS Foundation maintains a [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled.
+
+In order to escalate to the CoCP, email <coc-escalation@lists.openjsf.org>.
+
+## More Info
+
+For more information, refer to the full
+[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).

--- a/conduct/artifacts/CODE_OF_CONDUCT_PREAMBLE.md
+++ b/conduct/artifacts/CODE_OF_CONDUCT_PREAMBLE.md
@@ -6,8 +6,8 @@ The OpenJS Foundation and its member projects use a modified version of the Cont
 
 All recipients of reports commit to:
 
-- maintain the confidentiality with regard to the reporter and victim of an incident, and
-- participate in the path for escalation as outlined in the section on Escalation when required.
+- maintain the confidentiality with regard to the reporter and victim of an incident
+- participate in the path for escalation as outlined in the section on Escalation when required
 
 ## Report an issue in a project
 


### PR DESCRIPTION
For future tracking here's the steps taken/will be taken for the patching script:

This pull request includes the initial changes required to have a patching script for the CoC template. The patching script basically get's a commit SHA, and appends the original CoC template (available from code covenants website), and later applies the patching file (which will be included in the next pull request adding the script).

Steps needed to take to add the patching script:

1. Add a PREAMBLE file containing only the first portion of CoC
  - This pull request copies the first portion, and later applies changes only required to make sense in this context. (Removing some links and adding context to CoC modifications) 
2. Add a patching script (a different pull request)
  - Update the `base_url` on the patch script with the URL of the SHA commit from this pull request to use it as a baseline. 
  - Remove the CODE_OF_CONDUCT.md
  - Generate an initial patching file required to have the current version of CODE_OF_CONDUCT.md with minimal changes.
  - Push it to the patching script.
  
Co-authored by @joesepi 

