### PR TITLE
fix: remove broken link

### DIFF
--- a/meetings/2021/2021-10-12.md
+++ b/meetings/2021/2021-10-12.md
@@ -26,7 +26,7 @@
 - Program Committee for [OpenJS World](https://events.linuxfoundation.org/openjs-world/) ( [notes](https://docs.google.com/document/d/13i0FNqlSW-9EA0j92B2WB9w_Qzqgonzs9cxNDXvaKTY/edit?usp=sharing) ), happening Thursday!
 - Last Day for [Node LiFT Scholarships](https://www.linuxfoundation.org/diversity-inclusivity/lift-scholarship-2021-recipients/) Friday!
 - Thank you to the Node Security Release team - update out
-- Eemeli & others at [Unicode Conf](https://events.omg.org/iuc44/) this
+- Eemeli & others at Unicode Conf this
 - W3C Developer Days as part of [TPAC](https://www.w3.org/2021/10/TPAC/) Register [here](https://ti.to/w3c/tpac2021)
 - [nvm release](https://github.com/nvm-sh/nvm/releases)!!! [Node v16.11.0 Blog](https://nodejs.org/en/blog/release/v16.11.0/)
 - Welcome 3 new OpenJS Board Reps - Shane, Dan, Alex!


### PR DESCRIPTION
removes a link that's currently failing on the link checker. it's not really necessary to have this link, so I'm just entirely removing it.