### PR TITLE
meta: update links

### DIFF
--- a/project-resources/MEMBER_TRAVEL_FUND.md
+++ b/project-resources/MEMBER_TRAVEL_FUND.md
@@ -5,11 +5,18 @@
 To establish and administer a fund for members of the OpenJS Foundation to travel
 and spread knowledge about and support the Javascript ecosystem and the Foundation.
 
-### [Current Year Fund](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/TRAVEL_FUND/2022.md)
+### [Current Year Fund](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/TRAVEL_FUND/2023.md)
 
-### [2021 funds](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/TRAVEL_FUND/Achived_Travel_Fund_Records/2021.md)
+<details>
+  <summary>Previous funds</summary>
 
-### [2019 funds](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/TRAVEL_FUND/Achived_Travel_Fund_Records/2019.md)
+  * [2022](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/TRAVEL_FUND/Achived_Travel_Fund_Records/2022.md)
+  * [2021](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/TRAVEL_FUND/Achived_Travel_Fund_Records/2021.md)
+  * [2019](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/TRAVEL_FUND/Achived_Travel_Fund_Records/2019.md)
+  * [2018](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/TRAVEL_FUND/Achived_Travel_Fund_Records/2018.md)
+  * [2017 and 2016](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/TRAVEL_FUND/Achived_Travel_Fund_Records/2016-2017.md)
+
+</details>
 
 ## Requirements
 


### PR DESCRIPTION
- Update the current year fund link to point to the 2023 fund.
- List all previous funds.