### PR TITLE
Simplify CPC Board representation

### DIFF
--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -75,9 +75,9 @@ In this case the member will serve out the remainder of the term and must be re-
 The public portion of the CPC discussions and meetings will be open to all observers and members.
 
 The CPC shall meet regularly using tools that enable participation by the community.
-The meeting shall be directed by the CPC Chairperson.
-Responsibility for directing individual meetings may be delegated by the CPC Chairperson to any other CPC member.
-The CPC chairperson shall be one of the Voting members, and will be selected by the CPC members through consensus or if necessary a vote as described in the section titled "Voting".
+The meeting shall be directed by the CPC Chair or the CPC Vice Chair.
+Responsibility for directing individual meetings may be delegated by the CPC Chair or by the CPC Vice Chair to any other CPC member.
+The CPC Chair and CPC Vice Chair roles confer Voting member status, and will be selected by the CPC members through consensus or if necessary a vote as described in the section titled "Voting".
 Minutes or an appropriate recording shall be taken and made available to the community through accessible public postings.
 
 Voting members have the roles and responsibilities as outlined below.
@@ -139,7 +139,7 @@ Not withstanding the above, the Projects and the entire technical community will
 
 Leadership roles in OpenJS Foundation will be peer elected representatives of the community.
 
-For election of persons (such as the CPC Chairperson), a multiple-candidate method should be used, such as:
+For election of persons (such as the CPC Chair), a multiple-candidate method should be used, such as:
 
 * [Condorcet][] or
 * [Single Transferable Vote][]
@@ -150,17 +150,17 @@ Elections shall be done within the Projects by the Collaborators active in the P
 
 The CPC will elect from amongst Regular and Voting members of the CPC:
 
-* a CPC Chairperson to work on building an agenda for CPC meetings
+* a CPC Chair and a CPC Vice Chair to work on building an agenda for CPC meetings
 * CPC Directors to represent the Foundation's projects and related communities to the Board
 
 The term for each of these roles is one year (as defined in the [OpenJS Foundation bylaws][]).
 
-The CPC shall hold annual elections to select a CPC Chairperson and Directors.
+The CPC shall hold annual elections to select a CPC Chair, Vice Chair, and Directors.
 The CPC can choose to hold those elections at different times of the year or concurrently.
 
-There are no limits on the number of terms a CPC Chairperson or Director may serve.
+There are no limits on the number of terms a CPC Chair, Vice Chair, or Director may serve.
 
-The Chair may be (but is not required to be) a CPC Director.
+The CPC Chair and Vice Chair may be (but are not required to be) CPC Directors.
 
 ## Section 8. Board Representation
 

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -148,39 +148,31 @@ Multiple-candidate methods may be reduced to simple election by plurality when t
 No election is required if there is only one candidate and no objections to the candidates election.
 Elections shall be done within the Projects by the Collaborators active in the Project.
 
-The CPC will elect from amongst CPC members a CPC Chairperson to work on building an agenda for CPC meetings and a CPC Director to represent the CPC to the Board for a term of one year according to the OpenJS Foundation’s By-laws.
-The Chair and Director may be (but are not required to be) the same person.
-The CPC shall hold annual elections to select a CPC Chairperson and Director; there are no limits on the number of terms a CPC Chairperson or Director may serve.
+The CPC will elect from amongst CPC members:
 
-## Section 8. Board Representation
+* a CPC Chairperson to work on building an agenda for CPC meetings
+* CPC Directors to represent the Foundation's projects and related communities to the Board
 
-There are 3 Board seats earmarked for representation from the OpenJS Foundation, the Foundation's projects, and related communities.
+The term for each of these roles is one year (as defined in the [OpenJS Foundation bylaws][]).
 
-### The Primary CPC Director (as defined in §4.3(d) in the [OpenJS Foundation bylaws][])
+The CPC shall hold annual elections to select a CPC Chairperson and Directors.
+The CPC can decide to spread those elections across the year in order to avoid changing all of its Board representatives at once.
 
-The first of these board seats is filled as outlined in Section 7 on [Elections][] and is always in place.
+There are no limits on the number of terms a CPC Chairperson or Director may serve.
 
-**Primary CPC Director eligibility:** The Primary CPC Director must be a current CPC Member
+The Chair may be (but is not required to be) a CPC Director.
 
-**Primary CPC Director voting:** CPC Voting Members will vote on candidates
+## Section 8. Board Representation (CPC Directors)
 
-### The Secondary CPC Director (as defined in §4.3(e) in the [OpenJS Foundation bylaws][])
+There are Board seats allocated for CPC members to represent the Foundation's projects and related communities to the Board.
 
-The second board seat will be filled based on processes defined by the CPC and approved by the Voting CPC members and then the Board.
-The CPC members will review and either re-confirm or update the processes once per year.
+CPC Board representatives are called CPC Directors.
 
-**Secondary Director eligibility:** The Second CPC Director must be an [Active OpenJS Collaborator][] at the time of their selection, as defined in the CPC's Governance document.
+The number of CPC Directors is defined in §4.3(d) and §4.3(e) of the [OpenJS Foundation bylaws][].
 
-**Secondary Director voting:** CPC Voting Members will vote on candidates
+To be eligible, candidates must be current CPC Members.
 
-As described in the [Elections][] section a multiple candidate method will be be used for the voting for the first and second board members.
-
-### The Tertiary CPC Director (as defined in §4.3(f) in the [OpenJS Foundation bylaws][])
-
-The third board seat is earmarked to represent the Individual membership program.
-3 Platinum board members as well as 2000 members registered in the Individual membership program are required for it to activate.
-Candidates for the Individual Membership Director are to be nominated by voting members of the top-level committees of all projects and the voting CPC members.
-Active members of the Individual Membership program would then vote on the candidate of their choosing via an election system set by the CPC.
+The CPC Voting Members will vote on candidates as described in the [Elections][] section.
 
 ## Section 9. Decision Making
 

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -156,7 +156,7 @@ The CPC will elect from amongst CPC members:
 The term for each of these roles is one year (as defined in the [OpenJS Foundation bylaws][]).
 
 The CPC shall hold annual elections to select a CPC Chairperson and Directors.
-The CPC can decide to spread those elections across the year in order to avoid changing all of its Board representatives at once.
+The CPC can choose to hold those elections at different times of the year or concurrently.
 
 There are no limits on the number of terms a CPC Chairperson or Director may serve.
 

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -162,7 +162,7 @@ There are no limits on the number of terms a CPC Chairperson or Director may ser
 
 The Chair may be (but is not required to be) a CPC Director.
 
-## Section 8. Board Representation (CPC Directors)
+## Section 8. Board Representation
 
 There are Board seats allocated for CPC members to represent the Foundation's projects and related communities to the Board.
 

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -148,7 +148,7 @@ Multiple-candidate methods may be reduced to simple election by plurality when t
 No election is required if there is only one candidate and no objections to the candidates election.
 Elections shall be done within the Projects by the Collaborators active in the Project.
 
-The CPC will elect from amongst CPC members:
+The CPC will elect from amongst Regular and Voting members of the CPC:
 
 * a CPC Chairperson to work on building an agenda for CPC meetings
 * CPC Directors to represent the Foundation's projects and related communities to the Board

--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -170,7 +170,7 @@ CPC Board representatives are called CPC Directors.
 
 The number of CPC Directors is defined in §4.3(d) and §4.3(e) of the [OpenJS Foundation bylaws][].
 
-To be eligible, candidates must be current CPC Members.
+To be eligible, candidates must be Regular or Voting members of the CPC.
 
 The CPC Voting Members will vote on candidates as described in the [Elections][] section.
 


### PR DESCRIPTION
Closes #1054 and #1043

Assumes the Board will approve Bylaws changes similar to those drafted in  https://docs.google.com/document/d/1x-zRBQZShLMWE53J2yNlD88oudVWSj5UG8QfR2_RayI/edit?pli=1.

Summary of changes:

- Introduction of a CPC Vice Chair.
- Simplification of the various CPC Director roles by tying the number of CPC Directors to the number of active projects in the Foundation (to match how Silver Directors works), capped so that Member Directors always maintain simple majority.
For reference the Foundation currently lists 30 active projects (25 At Large and 5 Impact) and has 5 more projects in incubation. So we would just meet the threshold for adding a third CPC Director.
