### PR TITLE
fix: link breaks builds in 2021-10-26.md

### DIFF
--- a/meetings/2021/2021-10-26.md
+++ b/meetings/2021/2021-10-26.md
@@ -22,7 +22,7 @@ Private Session
 
 ### Announcements
 
-* jQuery Story in New Stack - check it out! https://thenewstack.io/why-outdated-jquery-is-still-the-dominant-javascript-library/
+* jQuery Story in New Stack - check it out! https ://thenewstack .io/why-outdated-jquery-is-still-the-dominant-javascript-library/ (Link works but is breaking Linkchecker PR tooling)
 * Reminder - attend Programming Committee calls on Thursdays to get involved with OpenJS World planning
 * Node.js v. 17 release out last week, Node 16 moving to LTS today! 
 * Thank you to the LiFT applicants and to the Node Mentorship team for reviewing - hope to have announcements out for receipients soon!

--- a/meetings/2021/2021-10-26.md
+++ b/meetings/2021/2021-10-26.md
@@ -22,7 +22,7 @@ Private Session
 
 ### Announcements
 
-* jQuery Story in New Stack - check it out! https ://thenewstack .io/why-outdated-jquery-is-still-the-dominant-javascript-library/ (Link works but is breaking Linkchecker PR tooling)
+* jQuery Story in New Stack - check it out! https://web.archive.org/web/20221205165626/https://thenewstack.io/why-outdated-jquery-is-still-the-dominant-javascript-library/
 * Reminder - attend Programming Committee calls on Thursdays to get involved with OpenJS World planning
 * Node.js v. 17 release out last week, Node 16 moving to LTS today! 
 * Thank you to the LiFT applicants and to the Node Mentorship team for reviewing - hope to have announcements out for receipients soon!


### PR DESCRIPTION
The link actually works, but I suspect newstack has implemented some bot rules that are breaking our linkchecker tooling