### PR TITLE
Add @Ethan-Arrowood to Regular Members list

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Anyone who has been active in the foundation or one of its member projects, as d
 - Dhruv Jain ([@maddhruv](https://github.com/maddhruv))
 - Divy Tolia ([@designmoreweb](https://github.com/designmoreweb))
 - Eemeli Aro ([@eemeli](https://github.com/eemeli))
+- Ethan Arrowood ([@Ethan-Arrowood](https://github.com/Ethan-Arrowood))
 - Jordan Harband ([@ljharb](https://github.com/ljharb))
 - Jory Burson ([@jorydotcom](https://github.com/jorydotcom))
 - Kris Borchers ([@kborchers](https://github.com/kborchers))


### PR DESCRIPTION
👋  I'm excited to participate more in OpenJS efforts across the board. I'm currently most involved in the Standards Working Group as well as partially the Next 10 effort. Subsequently, I will also be active in the CPC in order to maximize my collaboration effectiveness.

My major motivation is as a representative of WinterCG. I'm "bullish" on the values of WinterCG, and am eager to work on any effort that improves the future of JavaScript development across the wider ecosystem. 

🚀