### PR TITLE
chore: add label to ad-hoc-meeting template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ad-hoc-meeting.md
+++ b/.github/ISSUE_TEMPLATE/ad-hoc-meeting.md
@@ -2,8 +2,10 @@
 name: ad-hoc-meeting
 about: Used to organize ad-hoc meetings
 title: "[Ad hoc meeting] "
-labels: ''
-assignees: 'bensternthal'
+assignees:
+  - bensternthal
+labels:
+  - cross-project-council-agenda
 
 ---
 


### PR DESCRIPTION
This PR simply adds the `cross-project-council-agenda` to the `ad-hoc` meeting Issue Template.