### PR TITLE
chore: added codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @openjs-foundation/cpc


### PR DESCRIPTION
This PR adds a `CODEOWNERS` file so that new PRs have the CPC assigned for reviewers.