### PR TITLE
add @edsadr as a regular member to CPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Anyone who has been active in the foundation or one of its member projects, as d
 
 - Abigail Cabunoc Mayes ([@abbycabs](https://github.com/abbycabs))
 - Abraham Jr Agiri ([@codeekage](https://github.com/codeekage))
+- Adrian Estrada ([@edsadr](https://github.com/edsadr))
 - Antón Molleda ([@molant](https://github.com/molant))
 - Ben Hutton ([@relequestual](https://github.com/relequestual))
 - Ben Michel ([@obensource](https://github.com/obensource))


### PR DESCRIPTION
Hello everybody

Recently, I became the end-users director at the OpenJS foundation board, and I want to start being fully involved in all the CPC meetings. Please add me as a regular member; I will fully commit to my responsibilities described [here](https://github.com/openjs-foundation/cross-project-council/blob/main/governance/COMMUNITY_BOARD_SEAT_EXPECTATIONS.md)  and will attend as many meetings as I can.

