### PR TITLE
Remove CoC WG

### DIFF
--- a/governance/WORKING_GROUPS.md
+++ b/governance/WORKING_GROUPS.md
@@ -129,23 +129,7 @@ The [OpenJS Code of Conduct][] applies to this Working Group.
 
 ## Current Working Groups
 
-* [Code of Conduct](#code-of-conduct)
 * [Standards](#standards)
-
-### [Code of Conduct](https://github.com/openjs-foundation/code-of-conduct/)
-
-The purpose of the Code of Conduct Working Group is to define and maintain a set of resources/processes for use by the Foundation, its teams and its projects.
-
-Responsibilities include:
-
-* Define and maintain overarching Code of Conduct and moderation processes, documentation and resources as they pertain to the Foundation and the Cross Project Council.
-* Provide guidance/resources to implement the minimum Code of Conduct and moderation requirements for projects as part of Foundation membership as defined in the [Foundation Code of Conduct Requirements](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
-* Define and maintain template Code of Conduct and moderation processes and documentation as resources for the Foundation’s projects to use in whole or as guidance to develop their own processes, documentation, and resources, including training materials
-* Define and maintain Code of Conduct and moderation processes on handling violations within Foundation and its teams and groups (excluding Foundation projects).
-* Define and maintain Code of Conduct and moderation processes on handling escalations from Foundation projects, including communication
-* Identify, nominate, and approve team members on Foundations’s reporting list
-* Ensure engagement and input from projects on CoC policies and resources
-
 
 ### [Standards](https://github.com/openjs-foundation/standards/)
 


### PR DESCRIPTION
The CoC WG's work has been taken up by the CPC (in particular during working sessions) for a while. There's no point in keeping this defunct WG around.

_Note: the enforcement of the CoC remains with the CoC Panel, which is a different entity altogether._

Related: #1110 