### PR TITLE
Fix #1147 - Adds README for new community fund process to CPC repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,9 @@ If an Observer fails to meet these expectations they can be excluded from future
 * [Collaboration Space Progression](./collaboration-spaces/COLLABORATION_SPACE_PROGRESSION.md)
 * [Working Groups](./governance/WORKING_GROUPS.md)
 
-#### Other 
+#### Community Fund 
 
-* [Travel Fund Policy and Process](https://github.com/openjs-foundation/community-fund/blob/main/programs/travel-fund/README.md)
+* [Community / Travel Fund](./community-fund/COMMUNITY_FUND_POLICY.md) - OpenJS Foundation projects and their community members are able to take advantage of our community fund. 
 
 ### Policy Change Proposal Process
 
@@ -255,9 +255,8 @@ Discussion should be held in the open whenever possible. However, if you need to
 
 ## Getting Help
 
-### Project Resources & Travel Fund
 
-OpenJS Foundation projects and their community members are able to take advantage of several services and benefits, including the [Travel Fund Program](https://github.com/openjs-foundation/community-fund/blob/main/programs/travel-fund/README.md). 
+### Project Resources
 
 OpenJS Foundation Collaboration spaces are able to take advantage of several services and benefits as outlined in [COLLABORATION_NETWORK.md](./collaboration-spaces/COLLABORATION_NETWORK.md).
 

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -8,7 +8,7 @@ The OpenJS Foundation’s community fund supports travel and attendance at event
 * Standards body participants
 * Speakers
 
-The fund can cover the costs, in whole or in part, of a participant's hotel, airfare, and some event registrations.
+The fund can cover the costs, in whole or in part, of a participant's hotel, transportation, and some event registrations.
 Applicants should explore employer-sponsored funding options as their first source of financial support.
 Additionally, 25% of the community fund is allocated specifically to support diverse participants.
 Funding decisions are determined by a combination of need and potential impact.

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -1,0 +1,73 @@
+# Cross Project Council Community Fund
+
+## About The Community Fund
+
+The OpenJS Foundation’s community fund supports travel and attendance at events and activities directly related to OpenJS projects, technologies, or goals. We support travel for individuals who are:
+
+* Collaborators
+* Standards body participants
+* Speakers
+
+The fund can cover the costs, in whole or in part, of a participant's hotel, airfare, and some event registrations. Applicants should explore employer-sponsored funding options as their first source of financial support. Additionally, 25% of the community fund is allocated specifically to support diverse participants. Funding decisions  are determined by a combination of need and potential impact.
+
+## Community Fund Rules
+
+Valid travel expenses are:
+
+* Coach airfare tickets
+* Accommodations (Dates of the event plus one night prior are eligible for reimbursement)
+* Ground transportation to/from the airport
+
+NOTE: Funds may not be used for miscellaneous travel expenses including food, visa costs, non-airport transportation, baggage fees, etc. Generally, registration can be reimbursed if the attendee is speaking on behalf of OpenJS, the CPC or OpenJS-hosted projects. Funding is not transferable to another person, or any other event. 
+
+Travel fund assistance can only be received once per year.
+
+## How To Apply
+
+### Submit Travel Fund Request
+
+Submit your travel fund request to the Cross Project Council by completing [this application](https://forms.gle/QDt3iqoXXB5Ycovz8). Please see [Deadlines and Timelines](#deadlines-and-timelines) for information about cut-off dates. 
+
+### Wait For Approval
+
+The Cross Project Council reviews requests once per month. If your request is approved, you will be notified via email.
+
+## Getting Reimbursed
+
+### Submitting Expenses
+
+After the event, kindly submit your expenses within 30 days:
+
+* Fill out these [two forms](https://drive.google.com/drive/folders/1E-dTuqnIWpZN2NP-1ioAWzK_W2zSwa_P?usp=share_link)
+* Submit the forms along with **all** receipts [here](https://form.asana.com/?k=S6lGzAjHv2uv7M8llnhO_w&d=9283783873717)
+
+Please note that expenses without receipts can not be paid.
+
+### Submitting A Trip Report
+
+The process for submitting a trip report is TBD.
+<!-- Provide a trip report by filling out the following form. Preferably, also provide pictures and video of the 
+event for use on social media. -->
+
+### Receiving Payment
+
+Payments are processed within 30 days.
+
+## Deadlines and Timelines 
+
+The default deadline for submitting a community fund request is 8 weeks prior to the travel date to allow for all requests for an event to be reviewed at the same time. 
+
+Some events might have a fixed deadline for applications. Those deadlines will be posted to this repository.
+
+## CPC Review Schedule & Process 
+
+- CPC will review requests once a month in the CPC private session
+- Pending requests will be sent to the private CPC mailing list prior to the review meeting
+- Initial approval will be made by simple majority of the voting and regular members in attendance
+- Non-present members will have the oppurtunity to object to a decision over email
+
+## Getting Help
+
+Please direct any questions to operations@openjsf.org or reach out to Foundation staff on the OpenJS Foundation Slack
+
+

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -35,7 +35,8 @@ Please see [Deadlines and Timelines](#deadlines-and-timelines) for information a
 
 ### Wait For Approval
 
-The Cross Project Council reviews requests once per month. If your request is approved, you will be notified via email.
+The Cross Project Council reviews requests once per month. If your request is approved, you will be notified via email. Only
+approved requests are eligible for reimbursement. 
 
 ## Getting Reimbursed
 

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -73,6 +73,6 @@ Some events might have a fixed deadline for applications. Those deadlines will b
 
 ## Getting Help
 
-Please direct any questions to operations@openjsf.org or reach out to Foundation staff on the OpenJS Foundation Slack
+Please direct any questions to operations@openjsf.org or reach out to Foundation staff on the [OpenJS Foundation Slack]([url](https://openjs-foundation.slack.com/archives/C01AM9J51J8)https://openjs-foundation.slack.com/archives/C01AM9J51J8).
 
 

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -8,7 +8,10 @@ The OpenJS Foundation’s community fund supports travel and attendance at event
 * Standards body participants
 * Speakers
 
-The fund can cover the costs, in whole or in part, of a participant's hotel, airfare, and some event registrations. Applicants should explore employer-sponsored funding options as their first source of financial support. Additionally, 25% of the community fund is allocated specifically to support diverse participants. Funding decisions  are determined by a combination of need and potential impact.
+The fund can cover the costs, in whole or in part, of a participant's hotel, airfare, and some event registrations.
+Applicants should explore employer-sponsored funding options as their first source of financial support.
+Additionally, 25% of the community fund is allocated specifically to support diverse participants.
+Funding decisions are determined by a combination of need and potential impact.
 
 ## Community Fund Rules
 

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -25,7 +25,6 @@ NOTE: Funds may not be used for miscellaneous travel expenses including food, vi
 Generally, registration can be reimbursed if the attendee is speaking on behalf of OpenJS, the CPC, or OpenJS-hosted projects.
 Funding is not transferable to another person, or any other event. 
 
-Travel fund assistance can only be received once per year.
 
 ## How To Apply
 

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -10,7 +10,7 @@ The OpenJS Foundation’s community fund supports travel and attendance at event
 
 The fund can cover the costs, in whole or in part, of a participant's hotel, transportation, and some event registrations.
 Applicants should explore employer-sponsored funding options as their first source of financial support.
-Additionally, 25% of the community fund is allocated specifically to support diverse participants.
+Additionally, 25% of the community fund is allocated specifically to support underrepresented groups.
 Funding decisions are determined by a combination of need and potential impact.
 
 ## Community Fund Rules

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -17,7 +17,7 @@ Funding decisions are determined by a combination of need and potential impact.
 
 Valid travel expenses are:
 
-* Coach airfare tickets
+* Airfare, train, or ferry tickets in economy/coach class only
 * Accommodations (Dates of the event plus one night prior are eligible for reimbursement)
 * Ground transportation to/from the airport
 

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -21,7 +21,9 @@ Valid travel expenses are:
 * Accommodations (Dates of the event plus one night prior are eligible for reimbursement)
 * Ground transportation to/from the airport
 
-NOTE: Funds may not be used for miscellaneous travel expenses including food, visa costs, non-airport transportation, baggage fees, etc. Generally, registration can be reimbursed if the attendee is speaking on behalf of OpenJS, the CPC or OpenJS-hosted projects. Funding is not transferable to another person, or any other event. 
+NOTE: Funds may not be used for miscellaneous travel expenses including food, visa costs, non-airport transportation, baggage fees, etc.
+Generally, registration can be reimbursed if the attendee is speaking on behalf of OpenJS, the CPC, or OpenJS-hosted projects.
+Funding is not transferable to another person, or any other event. 
 
 Travel fund assistance can only be received once per year.
 
@@ -29,7 +31,8 @@ Travel fund assistance can only be received once per year.
 
 ### Submit Travel Fund Request
 
-Submit your travel fund request to the Cross Project Council by completing [this application](https://forms.gle/QDt3iqoXXB5Ycovz8). Please see [Deadlines and Timelines](#deadlines-and-timelines) for information about cut-off dates. 
+Submit your travel fund request to the Cross Project Council by completing [this application](https://forms.gle/QDt3iqoXXB5Ycovz8).
+Please see [Deadlines and Timelines](#deadlines-and-timelines) for information about cut-off dates. 
 
 ### Wait For Approval
 

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -69,8 +69,8 @@ Some events might have a fixed deadline for applications. Those deadlines will b
 
 - CPC will review requests once a month in the CPC private session
 - Pending requests will be sent to the private CPC mailing list prior to the review meeting
-- Initial approval will be made by simple majority of the voting and regular members in attendance
-- Non-present members will have the oppurtunity to object to a decision over email
+<!-- - Initial approval will be made by simple majority of the voting and regular members in attendance
+- Non-present members will have the oppurtunity to object to a decision over email -->
 
 ## Getting Help
 


### PR DESCRIPTION
This PR includes many updates to the community fund intake, review, and approval process. Highlights of this effort include

- Moving these docs into this repo, we will archive https://github.com/openjs-foundation/community-fund/ once merged
- Adding the form for intake
- Better definition of what the fund will cover
- Adding the DEI fund allocation
- Adding a new cadence and process for CPC reviews
- And more

Much thanks to @joesepi @PaulaPaul @tobie @mcollina @rginn and all the other folks in the CPC that contributed to this work.