### PR TITLE
chore: add Node.js's Website Learn Material as GSoD project

### DIFF
--- a/mentorship/2024/google-season-of-docs/README.md
+++ b/mentorship/2024/google-season-of-docs/README.md
@@ -38,6 +38,75 @@ If you would like to submit a proposal for an initiative that you would like to 
 
 ---
 
+## Projects
+
+### Project Idea: Node.js Learn -- Creating World-class Learning material for Node.js
+
+#### Problem
+
+The Node.js runtime is the world's most popular and widely adopted JavaScript runtime.
+Node.js enables JavaScript Developers to create the next big thing. Node.js is a fundmanetal cornterstone of the Web.
+
+Yet, as popular as Node.js might be, Node.js as a project needs fundamental learning material that allows people to kickstart and dive deep
+into the powerhouse of Node.js. Hundreds of content creators support the Node.js community with courses and learning material.
+Still, the Node.js project itself lacks fundamental learning material that allows newcomers and existing users of
+Node.js to get quickly started with the basics to the next big thing that Node.js provides.
+
+This project aims to update the existing Learn material available on the Node.js website and create new learning material
+Some of the expected tasks of this project include:
+
+- Reorganising and re-categorising the existing content
+- Rephrasing and improving existing content
+- Updating existing Learn outdated material
+- Introducing new learning material that is relevant to the user base of Node.js
+
+During this mentorship, the mentee can expect to be guided through the basics and fundamentals of Node.js to the gritty nitty
+and the shiny new features of Node.js.
+
+#### How would we measure success?
+
+The success of this project is measured on at least 3 pillars for Node.js's Learn material.
+
+- That we successfully audited the existing learning material/content
+  - Not all learn pages might require extensive updates, so the success criteria are personal and depend on outcomes
+    throughout the rundown of this mentorship.
+- That new learning material was created based on the project's needs. It is up to the mentee to come up with new ideas
+  and it is expected that the mentor will provide feedback and guidance regarding what needs to be done.
+- That both the mentor and the mentee are happy with the resulting outcome of this mentorship.
+
+Since these requirements are dynamic, the project's actual success indicator is determined by both parties
+agreement (mentor and mentee) that all the required work was accomplished.
+
+For the mentorship itself and the resulting outcomes, we can expect that the success of the project is measured by:
+
+- Improved documentation completeness, covering essential aspects of Node.js.
+- Enhanced clarity, ensuring that developers can easily understand the concepts and usage of Node.js.
+- Positive feedback and reduced queries related to Node.js usage on community forums and GitHub issues.
+
+#### What skills would a technical writer need to work on this project?
+
+#### Expected outcomes:
+
+* **Must Have**
+  - Updated Learning material covering Node.js features, including detailed explanations and usage examples.
+  - Improved organization and navigation within the Learning material to enhance usability.
+
+* **Nice To Have**
+  - Better SEO and structure for the Learn material
+  - Interactive examples or demos showcasing Node.js capabilities
+
+#### Volunteers / Mentors
+
+- Lead Mentor: [Claudio Wunder](https://github.com/ovflowd)
+- Co-mentors might include Node.js Core collaborators and other maintainers/collaborators of the Node.js website.
+
+#### Contact info
+
+Inquiries should, in general, be made through [OpenJS's Slack](https://openjsf.org/collaboration) on the #nodejs-website channel
+or through direct contact with the mentors through OpenJS's Slack or an e-mail to `cwunder@gnome.org`
+
+---
+
 ## Resources
 
 ### OpenJS Foundation 


### PR DESCRIPTION
This PR adds a Project Idea for 2024's Google Season of Docs tenure regarding improving Node.js's Learn material.