### PR TITLE
Fix #1264 add project contribution to checklist

### DIFF
--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -122,7 +122,7 @@ This is an informational checklist to help projects onboard into the OpenJS Foun
   * infrastructure
   * legal/governance help
 - [ ] Publish security policy (see [PROJECT_SECURITY_REPORTING](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/PROJECT_SECURITY_REPORTING.md))
-- [ ] Work with the foundation to sign a Project Contribution Agreement (if needed)
+- [ ] Work with the foundation to sign a [Project Contribution Agreement](https://docs.google.com/document/d/1Luq5JSUeDPGxj3vyttQvgItHPmj7v39QoKZqpJ9x_sU/edit?usp=sharing) (if needed)
 
 ## Post-graduation Checklist
 

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -122,6 +122,7 @@ This is an informational checklist to help projects onboard into the OpenJS Foun
   * infrastructure
   * legal/governance help
 - [ ] Publish security policy (see [PROJECT_SECURITY_REPORTING](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/PROJECT_SECURITY_REPORTING.md))
+- [ ] Work with the foundation to sign a Project Contribution Agreement (if needed)
 
 ## Post-graduation Checklist
 


### PR DESCRIPTION
Fixes #1264, note when this is merged I will update https://github.com/openjs-foundation/project-status/blob/HEAD/.github/ISSUE_TEMPLATE/00-project-onboarding-checklist-template.md

Note the project contribution agreement is the legal document that actually transfers the accounts, trademarks and limited power of attorney to the foundation.