### PR TITLE
add @anfibiacreativa to regular members list

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Anyone who has been active in the foundation or one of its member projects, as d
 - Michael Dawson ([@mhdawson](https://github.com/mhdawson))
 - Mike Samuel ([@mikesamuel](https://github.com/mikesamuel))
 - Mohammed Keyvanzadeh ([@VoltrexKeyva](https://github.com/VoltrexKeyva))
+- Natalia Venditto ([@anfibiacreativa](https://github.com/anfibiacreativa))
 - Nick O'Leary ([@knolleary](https://github.com/knolleary))
 - Nitin Kumar ([@snitin315](https://github.com/snitin315))
 - Paula Paul ([@paulapaul](https://github.com/paulapaul))


### PR DESCRIPTION
Hi everyone. I have finally blocked my calendar to prevent conflicts and although I'm advocating for a review of meeting times, I would like to be added to regular members, so I can participate of the CPC meetings at length -even those segments that are meant to be attended only by regular members- so I can be more effective in our goal to improve our community, standards and reach. 

I will be working with @edsadr in the ecosystem-report and I'm also part of the program committee. My current "day-work" is to make the JavaScript developer experience and tools better for developers building and deploying to one of the main public clouds and, as part of it -and vocationally- I am very involved in the OSS/JavaScript ecosystem, also acting as a liaison between the Node.js core team and the one of the most broadly used operating systems.

I am looking forward to adding value and contributing more extensively.