### PR TITLE
Update community fund approval process

### DIFF
--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -78,7 +78,7 @@ Some events might have a fixed deadline for applications. Those deadlines will b
 
 ## CPC Review Schedule & Process 
 
-- CPC will review requests once a month in the CPC private session
+- CPC will review requests as soon as possible, usually in the next CPC private session (every 2 weeks)
 - Pending requests will be sent to the private CPC mailing list prior to the review meeting.
   In the context of the lazy consensus process, the pending request list is a proposal to accept
   all of the requests. CPC members may raise any objections before the scheduled meeting,

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -86,6 +86,7 @@ Some events might have a fixed deadline for applications. Those deadlines will b
 - The CPC will use a scoring rubric to help with decision making
 - If any requests are rejected, an email with the rejected requests will be sent to the private
   CPC mailing list and CPC members will have 2 days to object before the decision is confirmed.
+  Approved requests will be confirmed right away.
 
 ### Scoring Rubric
 

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -80,7 +80,7 @@ Some events might have a fixed deadline for applications. Those deadlines will b
 
 - CPC will review requests once a month in the CPC private session
 - Pending requests will be sent to the private CPC mailing list prior to the review meeting.
-  In the context of the lazy concensus process, the pending request list is a proposal to accept
+  In the context of the lazy consensus process, the pending request list is a proposal to accept
   all of the requests. CPC members may raise any objections before the scheduled meeting,
   otherwise a final decision to approve a request can be confirmed in the meeting.
 - The CPC will use a scoring rubric to help with decision making

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -79,10 +79,13 @@ Some events might have a fixed deadline for applications. Those deadlines will b
 ## CPC Review Schedule & Process 
 
 - CPC will review requests once a month in the CPC private session
-- Pending requests will be sent to the private CPC mailing list prior to the review meeting
+- Pending requests will be sent to the private CPC mailing list prior to the review meeting.
+  In the context of the lazy concensus process, the pending request list is a proposal to accept
+  all of the requests. CPC members should raise any objections before the scheduled meeting,
+  otherwise a final decision to approve a request can be confirmed in the meeting.
 - The CPC will use a scoring rubric to help with decision making
-<!-- - Initial approval will be made by simple majority of the voting and regular members in attendance
-- Non-present members will have the oppurtunity to object to a decision over email -->
+- If any requests are rejected, an email with the rejected requests will be send to the private
+  CPC mailing list and CPC members will have 2 days to object before the decision is confirmed.
 
 ### Scoring Rubric
 

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -81,7 +81,7 @@ Some events might have a fixed deadline for applications. Those deadlines will b
 - CPC will review requests once a month in the CPC private session
 - Pending requests will be sent to the private CPC mailing list prior to the review meeting.
   In the context of the lazy concensus process, the pending request list is a proposal to accept
-  all of the requests. CPC members should raise any objections before the scheduled meeting,
+  all of the requests. CPC members may raise any objections before the scheduled meeting,
   otherwise a final decision to approve a request can be confirmed in the meeting.
 - The CPC will use a scoring rubric to help with decision making
 - If any requests are rejected, an email with the rejected requests will be sent to the private

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -84,7 +84,7 @@ Some events might have a fixed deadline for applications. Those deadlines will b
   all of the requests. CPC members should raise any objections before the scheduled meeting,
   otherwise a final decision to approve a request can be confirmed in the meeting.
 - The CPC will use a scoring rubric to help with decision making
-- If any requests are rejected, an email with the rejected requests will be send to the private
+- If any requests are rejected, an email with the rejected requests will be sent to the private
   CPC mailing list and CPC members will have 2 days to object before the decision is confirmed.
 
 ### Scoring Rubric


### PR DESCRIPTION
- Updated based on discuss in the CPC meeting today as well as follow on discussion with @tobie.

I think this might address both the concern I had as well concerns about streching out the process. It explains how approvals follow the lazy consensus process already, and extends it for rejections so that my concern about having a chance to object to those is factored in as well.