### PR TITLE
Fixes #1327 - Adds OpenJS Github Continuity Policy

### DIFF
--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -151,6 +151,7 @@ This is an informational checklist to help projects onboard into the OpenJS Foun
   * legal/governance help
 - [ ] Publish security policy (see [PROJECT_SECURITY_REPORTING](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/PROJECT_SECURITY_REPORTING.md))
 - [ ] Work with the foundation to sign a [Project Contribution Agreement](https://docs.google.com/document/d/1Luq5JSUeDPGxj3vyttQvgItHPmj7v39QoKZqpJ9x_sU/edit?usp=sharing) (if needed)
+- [ ] Implement an option from the [Github Continuity Policy](./project-resources/github-continuity-policy.md)
 
 ## Post-graduation Checklist
 

--- a/project-resources/github-continuity-policy.md
+++ b/project-resources/github-continuity-policy.md
@@ -1,0 +1,31 @@
+# OpenJS Github Continuity Policy
+
+## Summary
+
+This policy is intended to ensure that OpenJS GithHub projects remain accessible and manageable. 
+
+It addresses the following use cases:
+
+- Archiving projects when maintainers are no longer reachable
+- Managing projects and users when maintainers are inactive or unreachable
+- Adding or removing admins in emergency situations
+
+## Continuity Options for Projects
+
+### Option 1: Add The Executive Director As An Admin
+
+If you select this option, you will add the OpenJS Foundation executive director (currently https://github.com/rginn) 
+as an admin to your project.
+
+### Option 2: Add Your Organization To The OpenJS Enterprise
+
+If you select this option, you will add your Organization to the OpenJS Foundation enterprise account. Doing so gives 
+the foundation the option to become an organization owner if necessary.  The admins of the enterprise account are 
+currently limited to the [Executive Director](https://github.com/rginn) 
+and[ Director Of Program Management](https://github.com/bensternthal). 
+
+### Option 3: Opt-out
+
+Projects that feel their governance is sufficient to provide continuity may opt out of this policy by requesting an 
+exception from the CPC. This can be done by filing an issue in the 
+[CPC repository](https://github.com/openjs-foundation/cross-project-council/issues).


### PR DESCRIPTION
This PR adds the Github Continuity Policy discussed in #1327. Note there was discussion around the applicability of the policy to existing projects with at least one person suggesting that the policy only be enforced for new projects.

I would recommend making the policy retro-active and applicable to all projects, primarily for the following two reasons:

1. **Risk Mitigation:** Existing projects already face issues related to inactive or unreachable maintainers.  
2. **Consistency Across All Projects:** Applying the policy retroactively ensures a uniform standard.
