### PR TITLE
Update link for `Infrastructure Request` issue template

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ Discussion should be held in the open whenever possible. However, if you need to
 
 OpenJS Foundation Collaboration spaces are able to take advantage of several services and benefits as outlined in [COLLABORATION_NETWORK.md](./collaboration-spaces/COLLABORATION_NETWORK.md).
 
+<!-- original link id for infrastructure support -->
+<div id="help-with-project-infrastructure"></div>
+
 ### Help with LF IT supported infrastructure
 
 OpenJS projects that have formally engaged with LF IT to support one or more of their services should follow [this guide](./project-resources/requesting_LFIT_support.md) for requesting support. 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Discussion should be held in the open whenever possible. However, if you need to
 OpenJS Foundation Collaboration spaces are able to take advantage of several services and benefits as outlined in [COLLABORATION_NETWORK.md](./collaboration-spaces/COLLABORATION_NETWORK.md).
 
 <!-- original link id for infrastructure support -->
-<div id="help-with-project-infrastructure"></div>
+<a id="help-with-project-infrastructure"></a>
 
 ### Help with LF IT supported infrastructure
 


### PR DESCRIPTION
It appears that the link for infra requests has changed. Here a little patch with an update.