### PR TITLE
update impact acceptance criteria

### DIFF
--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -216,14 +216,13 @@ Impact Stage projects are expected to participate actively in CPC proceedings, a
 
 To graduate from At Large stage or for a new project to join as an Impact project, a project must meet the following criteria:
 
- * Document that it is being used successfully in production by at least two independent end users which, in the CPC’s judgement, are of adequate quality and scope.
+ * Demonstrate that it is being used successfully in production by at least two independent end users which, in the CPC’s judgement, are of adequate quality and scope.
  * Have a defined governing body of at least 5 or more members (owners and core maintainers), of which no more than 1/3 is affiliated with the same employer. In the case there are 5 governing members, 2 may be from the same employer. 
  * Have a documented and publicly accessible description of the project's governance, decision-making, contribution, and release processes. This is preferably laid out in a GOVERNANCE.md file and references a CONTRIBUTING.md and AUTHORS.md file showing the current and emeritus committers.
  * Demonstrate a substantial ongoing flow of commits and merged contributions.
  * Have a healthy number of committers from at least two organizations. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
  * Adopt the Foundation Code of Conduct.
  * Accept security reports and publicly disclose them after the fix has been made available.
- * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website).
  * Other metrics as defined by the applying Project during the application process in cooperation with the CPC.
  * Receive a supermajority vote from the CPC to move to Impact stage. Projects can move directly from At Large to Impact, if they can demonstrate sufficient maturity and have met all requirements. 
 


### PR DESCRIPTION
as discussed in the CPC working session today, a slight wording change and a removal of a criterion that seemed superfluous