### PR TITLE
Clarify why we are requiring at least 3 organizations in the Impact project leadership

### DIFF
--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -199,7 +199,7 @@ To be considered for the At Large Stage, the project must meet the following req
 
 #### Definition
 
-The Impact Stage is for projects that have reached their growth goals and are now on a sustaining cycle of development, maintenance, and long-term support. Impact Stage projects are used commonly in enterprise production environments and have large, well-established project communities.    
+The Impact Stage is for projects that have reached their growth goals and are now on a sustaining cycle of development, maintenance, and long-term support. Impact Stage projects are used commonly in enterprise production environments and have large, well-established project communities.
 Impact projects offer long-term stability guarantees, and therefore the governing body of Impact projects are expected to have representatives from at least three organizations.
 
 #### Examples

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -200,7 +200,7 @@ To be considered for the At Large Stage, the project must meet the following req
 #### Definition
 
 The Impact Stage is for projects that have reached their growth goals and are now on a sustaining cycle of development, maintenance, and long-term support. Impact Stage projects are used commonly in enterprise production environments and have large, well-established project communities.    
-Impact projects offer long-term stability guarantees, and therefore the governing body of Impact projects are expected to have representatives from at least threee organizations.
+Impact projects offer long-term stability guarantees, and therefore the governing body of Impact projects are expected to have representatives from at least three organizations.
 
 #### Examples
 

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -200,6 +200,7 @@ To be considered for the At Large Stage, the project must meet the following req
 #### Definition
 
 The Impact Stage is for projects that have reached their growth goals and are now on a sustaining cycle of development, maintenance, and long-term support. Impact Stage projects are used commonly in enterprise production environments and have large, well-established project communities.    
+Impact projects offer long-term stability guarantees, and therefore the governing body of Impact projects are expected to have representatives from at least threee organizations.
 
 #### Examples
 
@@ -217,7 +218,7 @@ Impact Stage projects are expected to participate actively in CPC proceedings, a
 To graduate from At Large stage or for a new project to join as an Impact project, a project must meet the following criteria:
 
  * Demonstrate that it is being used successfully in production by at least two independent end users which, in the CPC’s judgement, are of adequate quality and scope.
- * Have a defined governing body of at least 5 or more members (owners and core maintainers), of which no more than 1/3 is affiliated with the same employer. In the case there are 5 governing members, 2 may be from the same employer. 
+ * Have a defined governing body of at least 5 or more members (owners and core maintainers), of which no more than 1/3 is affiliated with the same employer. In the case there are 5 governing members, 2 may be from the same employer. This is to ensure that no single organization can control the project.
  * Have a documented and publicly accessible description of the project's governance, decision-making, contribution, and release processes. This is preferably laid out in a GOVERNANCE.md file and references a CONTRIBUTING.md and AUTHORS.md file showing the current and emeritus committers.
  * Demonstrate a substantial ongoing flow of commits and merged contributions.
  * Have a healthy number of committers from at least two organizations. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
@@ -225,7 +226,6 @@ To graduate from At Large stage or for a new project to join as an Impact projec
  * Accept security reports and publicly disclose them after the fix has been made available.
  * Other metrics as defined by the applying Project during the application process in cooperation with the CPC.
  * Receive a supermajority vote from the CPC to move to Impact stage. Projects can move directly from At Large to Impact, if they can demonstrate sufficient maturity and have met all requirements. 
-
 
 ### Incubating
 

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -218,7 +218,7 @@ Impact Stage projects are expected to participate actively in CPC proceedings, a
 To graduate from At Large stage or for a new project to join as an Impact project, a project must meet the following criteria:
 
  * Demonstrate that it is being used successfully in production by at least two independent end users which, in the CPC’s judgement, are of adequate quality and scope.
- * Have a defined governing body of at least 5 or more members (owners and core maintainers), of which no more than 1/3 is affiliated with the same employer. In the case there are 5 governing members, 2 may be from the same employer. This is to ensure that no single organization can control the project.
+ * Have a defined governing body of at least 5 or more members (owners and core maintainers), of which no more than 1/3 is affiliated with the same employer. In the case there are 5 governing members, 2 may be from the same employer. This limitation is to ensure broad representation and to prevent a single organization from having excessive influence on project decision-making.
  * Have a documented and publicly accessible description of the project's governance, decision-making, contribution, and release processes. This is preferably laid out in a GOVERNANCE.md file and references a CONTRIBUTING.md and AUTHORS.md file showing the current and emeritus committers.
  * Demonstrate a substantial ongoing flow of commits and merged contributions.
  * Have a healthy number of committers from at least two organizations. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -200,7 +200,7 @@ To be considered for the At Large Stage, the project must meet the following req
 #### Definition
 
 The Impact Stage is for projects that have reached their growth goals and are now on a sustaining cycle of development, maintenance, and long-term support. Impact Stage projects are used commonly in enterprise production environments and have large, well-established project communities.
-Impact projects offer long-term stability guarantees, and therefore the governing body of Impact projects are expected to have representatives from at least three organizations.
+Impact projects offer long-term stability guarantees, and therefore the governing bodies of Impact projects are expected to have representatives from at least three organizations.
 
 #### Examples
 
@@ -218,7 +218,7 @@ Impact Stage projects are expected to participate actively in CPC proceedings, a
 To graduate from At Large stage or for a new project to join as an Impact project, a project must meet the following criteria:
 
  * Demonstrate that it is being used successfully in production by at least two independent end users which, in the CPC’s judgement, are of adequate quality and scope.
- * Have a defined governing body of at least 5 or more members (owners and core maintainers), of which no more than 1/3 is affiliated with the same employer. In the case there are 5 governing members, 2 may be from the same employer. This limitation is to ensure broad representation and to prevent a single organization from having excessive influence on project decision-making.
+ * Have a defined governing body of at least 5 or more members (owners and core maintainers), of which no more than 1/3 is affiliated with the same employer. In the case there are 5 governing members, 2 may be from the same employer. This criterion is to ensure broad representation and to prevent a single organization from having excessive influence on project decision-making.
  * Have a documented and publicly accessible description of the project's governance, decision-making, contribution, and release processes. This is preferably laid out in a GOVERNANCE.md file and references a CONTRIBUTING.md and AUTHORS.md file showing the current and emeritus committers.
  * Demonstrate a substantial ongoing flow of commits and merged contributions.
  * Have a healthy number of committers from at least two organizations. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.


### PR DESCRIPTION
In https://github.com/nodejs/TSC/pull/1650, @richardlau mentioned that we don't explain _why_ that clause is needed, so I thought we should update it here as well.