### PR TITLE
Add ESLint email for code of conduct incidents

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,6 +6,7 @@
     * **AMP Project:** <code-of-conduct@amp.dev>
     * **Appium:** email maintainers
     * **Electron:** <coc@electronjs.org>
+    * **ESLint:** <conduct@eslint.org>
     * **Express.js:** <express-coc@lists.openjsf.org>
     * **Fastify:** <hello@matteocollina.com> or <tommydelved@gmail.com>
     * **HospitalRun:** <hello@hospitalrun.io>


### PR DESCRIPTION
Just adding ESLint's code of conduct email to the list.