### PR TITLE
✨ add decision-making process for CoC

### DIFF
--- a/conduct/COC_TEAM_CHARTER.md
+++ b/conduct/COC_TEAM_CHARTER.md
@@ -76,10 +76,9 @@ If not enough primary community members are available to meet those requirements
 
 Appeals to responses provided by the CoC Team itself should be handled by a different set of members than those responsible for the initial response.
 
-## Decision making process
+### Decision-making process for responding to incident reports
 
-The CoC Team uses the Cross Project Council's [Decision Making Process][decision-making].
-
+The CoC Team must agree on a resolution by complete, unanimous consensus. This means that all members involved in [handling](#handling-cases) an incident must agree on its resolution.
 
 [CoC]: https://code-of-conduct.openjsf.org/
 [CoC Policy]: https://github.com/openjs-foundation/cross-project-council/blob/main/conduct/COC_POLICY.md


### PR DESCRIPTION
per CPC working session today, we identified this is missing from the CoC.  it is [listed as a requirement for projects ](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/COC_POLICY.md#delegation-to-projects) (`#6`), but missing from the CPC's own CoC

edit: it was not missing, just not in the place we were looking for it. this PR now changes the decision-making process to something more appropriate for CoC incident response