### PR TITLE
docs: remove express from handling the CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,6 @@
     * **AMP Project:** <code-of-conduct@amp.dev>
     * **Appium:** email maintainers
     * **Electron:** <coc@electronjs.org>
-    * **Express.js:** <express-coc@lists.openjsf.org>
     * **Fastify:** <hello@matteocollina.com> or <tommydelved@gmail.com>
     * **HospitalRun:** <hello@hospitalrun.io>
     * **LoopBack** <tsc@loopback.io>


### PR DESCRIPTION
Express has decided that the OpenJS CoC team will handle reports, and we will adhere to the CoC adopted by the CPC

ref: https://github.com/expressjs/discussions/issues/349