### PR TITLE
Remove HospitalRun contact from CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,7 +7,6 @@
     * **Appium:** email maintainers
     * **Electron:** <coc@electronjs.org>
     * **Fastify:** <hello@matteocollina.com> or <tommydelved@gmail.com>
-    * **HospitalRun:** <hello@hospitalrun.io>
     * **LoopBack** <tsc@loopback.io>
     * **Node.js:** <report@nodejs.org>
     * **Node-RED:** <team@nodered.org>


### PR DESCRIPTION
Removed HospitalRun contact email from the code of conduct as the project is now Archived.