### PR TITLE
✨ flatten CPC chair group and allow for up to three co-chairs

### DIFF
--- a/CPC-CHARTER.md
+++ b/CPC-CHARTER.md
@@ -75,9 +75,9 @@ In this case the member will serve out the remainder of the term and must be re-
 The public portion of the CPC discussions and meetings will be open to all observers and members.
 
 The CPC shall meet regularly using tools that enable participation by the community.
-The meeting shall be directed by the CPC Chair or the CPC Vice Chair.
-Responsibility for directing individual meetings may be delegated by the CPC Chair or by the CPC Vice Chair to any other CPC member.
-The CPC Chair and CPC Vice Chair roles confer Voting member status, and will be selected by the CPC members through consensus or if necessary a vote as described in the section titled "Voting".
+The meeting shall be directed by the CPC Chairs.
+Responsibility for directing individual meetings may be delegated by the CPC Chairs to any other CPC member.
+The CPC Chair roles confer Voting member status, and will be selected by the CPC members through consensus or if necessary a vote as described in the section titled "Voting".
 Minutes or an appropriate recording shall be taken and made available to the community through accessible public postings.
 
 Voting members have the roles and responsibilities as outlined below.
@@ -139,7 +139,7 @@ Not withstanding the above, the Projects and the entire technical community will
 
 Leadership roles in OpenJS Foundation will be peer elected representatives of the community.
 
-For election of persons (such as the CPC Chair), a multiple-candidate method should be used, such as:
+For election of persons (such as the CPC Chairs), a multiple-candidate method should be used, such as:
 
 * [Condorcet][] or
 * [Single Transferable Vote][]
@@ -150,17 +150,17 @@ Elections shall be done within the Projects by the Collaborators active in the P
 
 The CPC will elect from amongst Regular and Voting members of the CPC:
 
-* a CPC Chair and a CPC Vice Chair to work on building an agenda for CPC meetings
+* CPC Chairs to work on building an agenda for CPC meetings
 * CPC Directors to represent the Foundation's projects and related communities to the Board
 
 The term for each of these roles is one year (as defined in the [OpenJS Foundation bylaws][]).
 
-The CPC shall hold annual elections to select a CPC Chair, Vice Chair, and Directors.
+The CPC shall hold annual elections to select CPC Chairs (up to three), and Directors.
 The CPC can choose to hold those elections at different times of the year or concurrently.
 
-There are no limits on the number of terms a CPC Chair, Vice Chair, or Director may serve.
+There are no limits on the number of terms a CPC Chair or Director may serve.
 
-The CPC Chair and Vice Chair may be (but are not required to be) CPC Directors.
+The CPC Chairs may be (but are not required to be) CPC Directors.
 
 ## Section 8. Board Representation
 

--- a/Dates-and-Reminders.md
+++ b/Dates-and-Reminders.md
@@ -13,6 +13,4 @@ CPC Regular voting members (2) | 1 Year | Oct: 1st & 2nd Week | Oct: 3rd week | 
 
 Position  | Term Length | Nomination Period | Voting Period | Term Start/End
 -- | -- | -- | -- | --
-CPC Chair  | 1 Year | Nov: 1st Week | Nov: 2nd Week | Nov 15
-CPC Vice Chair  | 1 Year | Nov: 1st Week | Nov: 2nd Week | Nov 15
-
+CPC Chairs (3) | 1 Year | Nov: 1st Week | Nov: 2nd Week | Nov 15

--- a/README.md
+++ b/README.md
@@ -112,12 +112,9 @@ CPC members should attend as many meetings as possible, and non-members are welc
 
 ## CPC Members
 
-### CPC Chair
+### CPC Chairs
 
 - Joe Sepi ([@joesepi](https://github.com/joesepi), IBM)
-
-### CPC Vice Chair
-
 - Tobie Langel ([@tobie](https://github.com/tobie), UnlockOpen)
 
 ### CPC Directors

--- a/governance/GITHUB_ORG_MANAGEMENT_POLICY.md
+++ b/governance/GITHUB_ORG_MANAGEMENT_POLICY.md
@@ -14,8 +14,7 @@ The following are granted Ownership permissions:
 
 * The OpenJS Executive Director
 * The OpenJS Director Of Program Management
-* The CPC Chair
-* The CPC Vice-Chair
+* The CPC Chairs
 
 ### Members
 

--- a/governance/GOVERNANCE.md
+++ b/governance/GOVERNANCE.md
@@ -53,7 +53,7 @@ To improve organizational transparency and collaboration between the CPC and Boa
 
 - CPC Directors should use their own judgement about what may be shared with the CPC. When in doubt they should abstain from sharing information and seek explicit permission to do so. In particular, information pertaining to a specific member, staff, or about legal matters should never be shared.
 - Board updates are not streamed and they are limited to CPC members.
-- CPC Directors wanting to report on a Board meeting should inform the CPC Chair at the beginning of the call so that sufficient time can be carved out at the end of the call for the update.
+- CPC Directors wanting to report on a Board meeting should inform the CPC Chairs at the beginning of the call so that sufficient time can be carved out at the end of the call for the update.
 
 ## Consensus Seeking Process
 
@@ -95,7 +95,7 @@ One must already be an [Active OpenJS Collaborator], as described below, to be e
 * The OpenJS Foundation Operations <operations@openjsf.org> team will:
    * Add the member to the GitHub `cpc-regular-members` [team][cpc regular members team]
    * Add the member to the `cpc-private` email list
-* The CPC Chair or Vice-Chair will introduce the new member at the next CPC meeting. 
+* The CPC Chairs will introduce the new member at the next CPC meeting.
 
 
 ### Not Approved


### PR DESCRIPTION
The CPC charter and governance do not distinguish any roles, responsibilities, or privileges between the CPC chair and the CPC vice chair, so they are effectively co-chairs in everything but name.

This proposal flattens the group to simply be chairs, or co-chairs, who would be elected as a group.

More significantly, it raises the number of (possible) chairs to a maximum of three.

> [!NOTE]
> Full disclosure: I personally ran for the chair and co-chair elections last year and lost both.  I have not decided whether I will run again in the future.

> [!IMPORTANT]
> I am leaving this topic off the CPC meeting agenda for now because I will not be able to attend the next two weeks' meetings, and would like to be present if/when this topic is discussed.