### PR TITLE
docs: clarify OpenJS Foundation CoC escalation "https://github.com/openjs-foundation/project-status/issues/131"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -25,6 +25,13 @@
         
     please email the [Code of Conduct Team (CoC Team)][CoC Team] at <coc@openjsf.org> or contact any of its members.
 
+### Escalation to the OpenJS Foundation
+
+If a report cannot be handled at the project level, involves a project maintainer, or if there is a conflict of interest, lack of response, or urgency, the incident may be escalated to the OpenJS Foundation Code of Conduct Team.
+
+To escalate a report, email the OpenJS Foundation Code of Conduct Team at <coc@openjsf.org> or contact any of its members directly.
+
+
 ### Appeal a decision
 
 Harmed individuals and accused individuals may [appeal][] the decision to the CoC Team up to thirty (30) days after a response was provided if they believe that the process was not followed properly. Appeals do not delay or block the execution of decisions communicated in the response.


### PR DESCRIPTION
This PR clarifies and explicitly documents the OpenJS Foundation Code of Conduct escalation path to improve discoverability for contributors, especially during onboarding. Fixes #131.