### PR TITLE
Fix RRULE evaluation for recurring CPC working session events

### DIFF
--- a/.github/workflows/cpc-working-session-agenda.yml
+++ b/.github/workflows/cpc-working-session-agenda.yml
@@ -10,7 +10,7 @@ jobs:
   create-agenda:
     runs-on: ubuntu-latest
     steps:
-      - name: Check iCal for CPC Working Session meeting occuring today
+      - name: Check iCal for CPC Working Session meeting occurring today
         id: check-meeting
         run: |
           # Fetch the iCal feed
@@ -33,50 +33,155 @@ jobs:
           PASSCODE=""
           MEETING_TIME=""
 
-          # Extract events with "CPC working session" (case insensitive) occurring today
-          awk -v today="$TODAY" '
+          # Extract all CPC working session events (without date filtering)
+          # Recurring events only store the series start date in DTSTART,
+          # so we must evaluate the RRULE to determine if today is an occurrence.
+          awk '
           BEGIN { RS="BEGIN:VEVENT"; FS="\n"; ORS="" }
-          /[Cc][Pp][Cc] [Ww]orking [Ss]ession/ && $0 ~ "DTSTART[^:]*:" today {
+          /[Cc][Pp][Cc] [Ww]orking [Ss]ession/ {
             print "BEGIN:VEVENT" $0
           }
           ' /tmp/calendar.ics > /tmp/cpc_events.ics
 
           if [ -s /tmp/cpc_events.ics ]; then
-            echo "Found CPC working session on $TODAY_DISPLAY"
-            MEETING_FOUND="true"
+            echo "Found CPC working session event(s) in calendar"
 
-            # Extract Zoom link from LOCATION field
-            ZOOM_LINK=$(grep "^LOCATION:" /tmp/cpc_events.ics | grep -oE 'https://zoom-lfx\.platform\.linuxfoundation\.org/meeting/[0-9]+\?password=[a-f0-9-]+' | head -1)
+            # Split events into separate files for processing
+            awk '/BEGIN:VEVENT/{n++; f="/tmp/cpc_event_" sprintf("%02d",n) ".ics"} n>0{print > f}' /tmp/cpc_events.ics
 
-            # If not in LOCATION, try URL field
-            if [ -z "$ZOOM_LINK" ]; then
-              ZOOM_LINK=$(grep "^URL" /tmp/cpc_events.ics | grep -oE 'https://zoom-lfx\.platform\.linuxfoundation\.org/meeting/[0-9]+\?password=[a-f0-9-]+' | head -1)
-            fi
+            for EVENT_FILE in /tmp/cpc_event_*.ics; do
+              [ -f "$EVENT_FILE" ] || continue
 
-            # Extract passcode from DESCRIPTION
-            PASSCODE=$(grep "^DESCRIPTION:" /tmp/cpc_events.ics | sed -n 's/.*Passcode:[[:space:]]*\([0-9]*\).*/\1/p' | head -1)
+              echo "---"
+              echo "Processing event from $EVENT_FILE"
 
-            # Extract meeting time from DTSTART
-            TIME_RAW=$(grep "DTSTART" /tmp/cpc_events.ics | head -1 | sed -n 's/.*T\([0-9]\{4\}\).*/\1/p')
-            if [ -n "$TIME_RAW" ]; then
-              HOUR=${TIME_RAW:0:2}
-              HOUR_12=$((10#$HOUR % 12))
-              [ $HOUR_12 -eq 0 ] && HOUR_12=12
-              if [ $((10#$HOUR)) -lt 12 ]; then
-                AMPM="AM"
-              else
-                AMPM="PM"
+              # Extract DTSTART date (YYYYMMDD)
+              DTSTART=$(grep "DTSTART" "$EVENT_FILE" | head -1 | grep -oE '[0-9]{8}' | head -1)
+              echo "DTSTART: $DTSTART"
+
+              if [ -z "$DTSTART" ]; then
+                echo "No DTSTART found, skipping"
+                continue
               fi
-              MEETING_TIME="${HOUR_12}:00 ${AMPM} UTC"
-            else
-              MEETING_TIME="See calendar for time"
-            fi
 
-            echo "Zoom Link: $ZOOM_LINK"
-            echo "Passcode: $PASSCODE"
-            echo "Meeting Time: $MEETING_TIME"
+              # Check if this is a recurring event with RRULE
+              if grep -q "RRULE:" "$EVENT_FILE"; then
+                RRULE=$(grep "RRULE:" "$EVENT_FILE" | head -1)
+                echo "RRULE: $RRULE"
+
+                # Check if the event recurs on the right day of the week
+                BYDAY=$(echo "$RRULE" | sed -n 's/.*BYDAY=\([A-Z,+0-9]*\).*/\1/p')
+                echo "BYDAY: $BYDAY"
+
+                # Get today's day abbreviation (MO, TU, WE, TH, FR, SA, SU)
+                TODAY_DOW=$(date +%u) # 1=Monday, 7=Sunday
+                case $TODAY_DOW in
+                  1) TODAY_DAY="MO" ;;
+                  2) TODAY_DAY="TU" ;;
+                  3) TODAY_DAY="WE" ;;
+                  4) TODAY_DAY="TH" ;;
+                  5) TODAY_DAY="FR" ;;
+                  6) TODAY_DAY="SA" ;;
+                  7) TODAY_DAY="SU" ;;
+                esac
+                echo "Today is: $TODAY_DAY"
+
+                if ! echo "$BYDAY" | grep -q "$TODAY_DAY"; then
+                  echo "Event does not recur on $TODAY_DAY, skipping"
+                  continue
+                fi
+
+                # Get the interval (default to 1 if not specified)
+                INTERVAL=$(echo "$RRULE" | sed -n 's/.*INTERVAL=\([0-9]*\).*/\1/p')
+                INTERVAL=${INTERVAL:-1}
+                echo "Interval: $INTERVAL weeks"
+
+                # Calculate if today is a valid occurrence
+                DTSTART_FMT="${DTSTART:0:4}-${DTSTART:4:2}-${DTSTART:6:2}"
+                TODAY_FMT="${TODAY:0:4}-${TODAY:4:2}-${TODAY:6:2}"
+                DTSTART_SEC=$(date -d "$DTSTART_FMT" +%s)
+                TODAY_SEC=$(date -d "$TODAY_FMT" +%s)
+
+                DIFF_SEC=$((TODAY_SEC - DTSTART_SEC))
+                if [ $DIFF_SEC -lt 0 ]; then
+                  echo "Today is before DTSTART, skipping"
+                  continue
+                fi
+
+                DIFF_WEEKS=$((DIFF_SEC / 604800))
+                echo "Weeks since DTSTART: $DIFF_WEEKS"
+
+                if [ $((DIFF_WEEKS % INTERVAL)) -eq 0 ]; then
+                  echo "Today IS a scheduled occurrence (week $DIFF_WEEKS, interval $INTERVAL)"
+
+                  # Check EXDATE - skip if today is excluded
+                  EXCLUDED="false"
+                  while IFS= read -r EXDATE_LINE; do
+                    EXDATE_DATE=$(echo "$EXDATE_LINE" | grep -oE '[0-9]{8}' | head -1)
+                    if [ "$EXDATE_DATE" = "$TODAY" ]; then
+                      echo "Today is in EXDATE list, skipping"
+                      EXCLUDED="true"
+                      break
+                    fi
+                  done < <(grep "EXDATE" "$EVENT_FILE")
+
+                  if [ "$EXCLUDED" = "true" ]; then
+                    continue
+                  fi
+
+                  MEETING_FOUND="true"
+                else
+                  echo "Today is NOT a scheduled occurrence (off-week)"
+                  continue
+                fi
+              else
+                # Single event - check if DTSTART matches today
+                if [ "$DTSTART" = "$TODAY" ]; then
+                  echo "Found single event on today"
+                  MEETING_FOUND="true"
+                else
+                  echo "Single event not on today, skipping"
+                  continue
+                fi
+              fi
+
+              # If we got here, meeting was found - extract details
+              if [ "$MEETING_FOUND" = "true" ]; then
+                # Extract Zoom link from LOCATION field
+                ZOOM_LINK=$(grep "^LOCATION:" "$EVENT_FILE" | grep -oE 'https://zoom-lfx\.platform\.linuxfoundation\.org/meeting/[0-9]+\?password=[a-f0-9-]+' | head -1)
+
+                # If not in LOCATION, try URL field
+                if [ -z "$ZOOM_LINK" ]; then
+                  ZOOM_LINK=$(grep "^URL" "$EVENT_FILE" | grep -oE 'https://zoom-lfx\.platform\.linuxfoundation\.org/meeting/[0-9]+\?password=[a-f0-9-]+' | head -1)
+                fi
+
+                # Extract passcode from DESCRIPTION
+                PASSCODE=$(grep "^DESCRIPTION:" "$EVENT_FILE" | sed -n 's/.*Passcode:[[:space:]]*\([0-9]*\).*/\1/p' | head -1)
+
+                # Extract meeting time from DTSTART
+                TIME_RAW=$(grep "DTSTART" "$EVENT_FILE" | head -1 | sed -n 's/.*T\([0-9]\{4\}\).*/\1/p')
+                if [ -n "$TIME_RAW" ]; then
+                  HOUR=${TIME_RAW:0:2}
+                  HOUR_12=$((10#$HOUR % 12))
+                  [ $HOUR_12 -eq 0 ] && HOUR_12=12
+                  if [ $((10#$HOUR)) -lt 12 ]; then
+                    AMPM="AM"
+                  else
+                    AMPM="PM"
+                  fi
+                  MEETING_TIME="${HOUR_12}:00 ${AMPM} Pacific Time"
+                else
+                  MEETING_TIME="See calendar for time"
+                fi
+
+                echo "Zoom Link: $ZOOM_LINK"
+                echo "Passcode: $PASSCODE"
+                echo "Meeting Time: $MEETING_TIME"
+                break
+              fi
+            done
           else
-            echo "No CPC working session found on $TODAY_DISPLAY"
+            echo "No CPC working session events found in calendar"
           fi
 
           # Output results


### PR DESCRIPTION
## Problem

The GitHub Action for creating CPC working session agendas was not detecting meetings. It ran on 2026-02-10 and reported "No CPC working session found" even though one was on the calendar.

## Root Cause

The `awk` script was doing simple text matching, looking for the literal target date in the `DTSTART` field:

```
$0 ~ "DTSTART[^:]*:" today
```

But **recurring iCal events only store the series start date** in `DTSTART` (e.g., `20241022`), not each individual occurrence. The actual occurrences are computed from `DTSTART` + `RRULE`. So the script would never match any date other than the original series start date.

## Fix

Replace the naive text matching with proper RRULE evaluation:

1. Extract all CPC working session events without date filtering
2. For each event, evaluate the `RRULE` to determine if today is a valid occurrence:
   - Check `BYDAY` matches today's day of the week
   - Compute weeks since `DTSTART` and check divisibility by `INTERVAL`
   - Check `EXDATE` entries to skip cancelled occurrences
3. Fall back to direct `DTSTART` matching for single (non-recurring) events

Tested against multiple dates including meeting days, off-weeks, excluded dates, and wrong days of the week.