### PR TITLE
Add annual project presentation guidelines and schedules

### DIFF
--- a/project-resources/annual-project-presentations.md
+++ b/project-resources/annual-project-presentations.md
@@ -4,7 +4,7 @@ Each active OpenJS Foundation project presents to the Cross Project Council (CPC
 
 ## How It Works
 
-At the start of each year, the CPC publishes a schedule assigning each active project to a CPC meeting date, spread evenly across the year. CPC members liaise with the OpenJS PM team to coordinate invites and handle rescheduling as needed. If a project maintainer can't make their date, a CPC member familiar with the project can present on their behalf.
+At the start of each year, the CPC publishes a schedule of available meeting dates, spread evenly across the year. Projects sign up for a slot that works for them. Projects can liaise with the OpenJS Program Managers to coordinate invites and handle rescheduling as needed.
 
 Presentations should be roughly **10–15 minutes** with time for questions afterward.
 
@@ -13,69 +13,34 @@ Presentations should be roughly **10–15 minutes** with time for questions afte
 Projects should touch on these topics, spending more time on whatever is most relevant:
 
 1. **Year in review** — Major releases, milestones, or highlights from the past year.
-1. **Support availability** — Are consumers and contributors getting the help they need?
-2. **Contributor and maintainer health** — Enough active maintainers? Any bus-factor risks?
-3. **Project category** — Is the current category (At-Large, Impact) still accurate?
-4. **Security** — Any concerns?
-5. **Sustainability** — Participating in or interested in any programs (ESP etc.)?
-6. **Resource needs** — Anything needed from the CPC or Foundation?
-
----
+1. **Contributor and maintainer health** — Enough active maintainers? Any bus-factor risks?
+1. **Project category** — Is the current category (At-Large, Impact) still accurate?
+1. **Security** — Any concerns?
+1. **Sustainability** — Participating in or interested in any programs (ESP etc.)?
+1. **Resource needs** — Anything needed from the CPC or Foundation?
 
 ## 2026 Presentation Schedule
 
-One project per CPC meeting. Impact projects are listed first, followed by At-Large.
+One project per CPC meeting. 
 
 | Date | Project | Category |
 |------|---------|----------|
-| Apr 28 | Appium | Impact |
-| May 12 | Electron | Impact |
-| May 26 | Express | Impact |
-| Jun 09 | jQuery | Impact |
-| Jun 23 | Node.js | Impact |
-| Jul 07 | webpack | Impact |
-| Jul 21 | AMP | At-Large |
-| Aug 04 | architect | At-Large |
-| Aug 18 | Cosmos | At-Large |
-| Sep 01 | ESLint | At-Large |
-| Sep 15 | Fastify | At-Large |
-| Sep 29 | Globalize | At-Large |
-| Oct 13 | Grunt | At-Large |
-| Oct 27 | Interledger.js | At-Large |
-| Nov 10 | JerryScript | At-Large |
-| Nov 24 | Jest | At-Large |
-| Dec 08 | Lodash | At-Large |
-| Dec 22 | LoopBack | At-Large |
+| Apr 28 | TBD | TBD |
+| May 12 | TBD | TBD |
+| May 26 | TBD | TBD |
+| Jun 09 | TBD | TBD |
+| Jun 23 | TBD | TBD |
+| Jul 07 | TBD | TBD |
+| Jul 21 | TBD | TBD |
+| Aug 04 | TBD | TBD |
+| Aug 18 | TBD | TBD |
+| Sep 01 | TBD | TBD |
+| Sep 15 | TBD | TBD |
+| Sep 29 | TBD | TBD |
+| Oct 13 | TBD | TBD |
+| Oct 27 | TBD | TBD |
+| Nov 10 | TBD | TBD |
+| Nov 24 | TBD | TBD |
+| Dec 08 | TBD | TBD |
+| Dec 22 | TBD | TBD |
 
-## 2027 Presentation Schedule
-
-Remaining projects from the current cycle, followed by TBD slots.
-
-| Date | Project | Category |
-|------|---------|----------|
-| Jan 05 | Marko | At-Large |
-| Jan 19 | messageformat | At-Large |
-| Feb 02 | Mocha | At-Large |
-| Feb 16 | NativeScript | At-Large |
-| Mar 02 | Node-RED | At-Large |
-| Mar 16 | nvm | At-Large |
-| Mar 30 | QUnit | At-Large |
-| Apr 13 | WebdriverIO | At-Large |
-| Apr 27 | TBD | |
-| May 11 | TBD | |
-| May 25 | TBD | |
-| Jun 08 | TBD | |
-| Jun 22 | TBD | |
-| Jul 06 | TBD | |
-| Jul 20 | TBD | |
-| Aug 03 | TBD | |
-| Aug 17 | TBD | |
-| Aug 31 | TBD | |
-| Sep 14 | TBD | |
-| Sep 28 | TBD | |
-| Oct 12 | TBD | |
-| Oct 26 | TBD | |
-| Nov 09 | TBD | |
-| Nov 23 | TBD | |
-| Dec 07 | TBD | |
-| Dec 21 | TBD | |

--- a/project-resources/annual-project-presentations.md
+++ b/project-resources/annual-project-presentations.md
@@ -1,0 +1,81 @@
+# Annual Project Presentation Process
+
+Each active OpenJS Foundation project presents to the Cross Project Council (CPC) once per year. The presentation conveys the status of the project and provides a forum to ask for help and to ask questions. Presentations can be formal or informal, whatever works best for the project.  
+
+## How It Works
+
+At the start of each year, the CPC publishes a schedule assigning each active project to a CPC meeting date, spread evenly across the year. CPC members liaise with the OpenJS PM team to coordinate invites and handle rescheduling as needed. If a project maintainer can't make their date, a CPC member familiar with the project can present on their behalf.
+
+Presentations should be roughly **10–15 minutes** with time for questions afterward.
+
+## What to Cover
+
+Projects should touch on these topics, spending more time on whatever is most relevant:
+
+1. **Year in review** — Major releases, milestones, or highlights from the past year.
+1. **Support availability** — Are consumers and contributors getting the help they need?
+2. **Contributor and maintainer health** — Enough active maintainers? Any bus-factor risks?
+3. **Project category** — Is the current category (At-Large, Impact) still accurate?
+4. **Security** — Any concerns?
+5. **Sustainability** — Participating in or interested in any programs (ESP etc.)?
+6. **Resource needs** — Anything needed from the CPC or Foundation?
+
+---
+
+## 2026 Presentation Schedule
+
+One project per CPC meeting. Impact projects are listed first, followed by At-Large.
+
+| Date | Project | Category |
+|------|---------|----------|
+| Apr 28 | Appium | Impact |
+| May 12 | Electron | Impact |
+| May 26 | Express | Impact |
+| Jun 09 | jQuery | Impact |
+| Jun 23 | Node.js | Impact |
+| Jul 07 | webpack | Impact |
+| Jul 21 | AMP | At-Large |
+| Aug 04 | architect | At-Large |
+| Aug 18 | Cosmos | At-Large |
+| Sep 01 | ESLint | At-Large |
+| Sep 15 | Fastify | At-Large |
+| Sep 29 | Globalize | At-Large |
+| Oct 13 | Grunt | At-Large |
+| Oct 27 | Interledger.js | At-Large |
+| Nov 10 | JerryScript | At-Large |
+| Nov 24 | Jest | At-Large |
+| Dec 08 | Lodash | At-Large |
+| Dec 22 | LoopBack | At-Large |
+
+## 2027 Presentation Schedule
+
+Remaining projects from the current cycle, followed by TBD slots.
+
+| Date | Project | Category |
+|------|---------|----------|
+| Jan 05 | Marko | At-Large |
+| Jan 19 | messageformat | At-Large |
+| Feb 02 | Mocha | At-Large |
+| Feb 16 | NativeScript | At-Large |
+| Mar 02 | Node-RED | At-Large |
+| Mar 16 | nvm | At-Large |
+| Mar 30 | QUnit | At-Large |
+| Apr 13 | WebdriverIO | At-Large |
+| Apr 27 | TBD | |
+| May 11 | TBD | |
+| May 25 | TBD | |
+| Jun 08 | TBD | |
+| Jun 22 | TBD | |
+| Jul 06 | TBD | |
+| Jul 20 | TBD | |
+| Aug 03 | TBD | |
+| Aug 17 | TBD | |
+| Aug 31 | TBD | |
+| Sep 14 | TBD | |
+| Sep 28 | TBD | |
+| Oct 12 | TBD | |
+| Oct 26 | TBD | |
+| Nov 09 | TBD | |
+| Nov 23 | TBD | |
+| Dec 07 | TBD | |
+| Dec 21 | TBD | |


### PR DESCRIPTION
Fixes #1739 

This is an initial attempt at outlining how the annual presentation process could work, including a schedule. I tried to keep this as lightweight as possible and have the first presentation scheduled for April so that we have time to socialize and get contacts. 

Suggestions and changes are very very weclome.