### PR TITLE
Email Audit, Implement support@

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/collaboration-spaces/COLLABORATION_SPACE_PROGRESSION.md
+++ b/collaboration-spaces/COLLABORATION_SPACE_PROGRESSION.md
@@ -21,7 +21,7 @@ This governance policy sets forth the proposal process for collaboration spaces 
 
 ### Collaboration Space Proposal Requirements
 
-The proposal to form a new collaboration space in the OpenJS Foundation can be made via an email to operations@openjsf.org with a filled out [Collaboration Space Application Template](./NEW_COLLABORATION_SPACE_APPLICATION.md). The initial application will have a silent period for internal only discussion. If your application is denied during this phase you will be notified privately. If there are no objections to the application, the space will given an `incubation` status and begin the onboarding process. **Note** the `incubation` status is temporary as we determine if the space is a good fit. At any time during the `incubation` process a space can withdraw either voluntarily or at the request of the CPC.
+The proposal to form a new collaboration space in the OpenJS Foundation can be made via an email to support@openjsf.org with a filled out [Collaboration Space Application Template](./NEW_COLLABORATION_SPACE_APPLICATION.md). The initial application will have a silent period for internal only discussion. If your application is denied during this phase you will be notified privately. If there are no objections to the application, the space will given an `incubation` status and begin the onboarding process. **Note** the `incubation` status is temporary as we determine if the space is a good fit. At any time during the `incubation` process a space can withdraw either voluntarily or at the request of the CPC.
 
 #### Roles
 
@@ -41,7 +41,7 @@ The Application Champion is a member of the CPC or Foundation staff who commits 
 
 #### Process
 
-1. Initial email sent to operations@openjsf.org with filled out [Collaboration Space Application Template](./NEW_COLLABORATION_SPACE_APPLICATION.md)
+1. Initial email sent to support@openjsf.org with filled out [Collaboration Space Application Template](./NEW_COLLABORATION_SPACE_APPLICATION.md)
 1. Silent period. Internal only discussion.
 1. Initial acceptance as [Incubating] Collaboration Space.
 1. An acknowledgement is sent to the applicant by Foundation staff within 48 hours (striving to reply within 24 hours when possible).

--- a/community-fund/COMMUNITY_FUND_POLICY.md
+++ b/community-fund/COMMUNITY_FUND_POLICY.md
@@ -118,6 +118,4 @@ Total Amount Requested Less Than X (e.g. $1,500) | +1
 
 ## Getting Help
 
-Please direct any questions to operations@openjsf.org or reach out to Foundation staff on the [OpenJS Foundation Slack]([url](https://openjs-foundation.slack.com/archives/C01AM9J51J8)https://openjs-foundation.slack.com/archives/C01AM9J51J8).
-
-
+Please direct any questions to support@openjsf.org or reach out to Foundation staff on the [OpenJS Foundation Slack]([url](https://openjs-foundation.slack.com/archives/C01AM9J51J8)https://openjs-foundation.slack.com/archives/C01AM9J51J8).

--- a/governance/GOVERNANCE.md
+++ b/governance/GOVERNANCE.md
@@ -97,7 +97,7 @@ One must already be an [Active OpenJS Collaborator], as described below, to be e
 ### Approved
 
 * The CPC will create a pull request adding your name to the Regular member list in the [README.md][README].
-* The OpenJS Foundation Operations <operations@openjsf.org> team will:
+* The OpenJS Foundation Operations <support@openjsf.org> team will:
    * Add the member to the GitHub `cpc-regular-members` [team][cpc regular members team]
    * Add the member to the `cpc-private` email list
 * The CPC Chair or Vice-Chair will introduce the new member at the next CPC meeting. 

--- a/governance/IP_POLICY_GUIDANCE.md
+++ b/governance/IP_POLICY_GUIDANCE.md
@@ -93,7 +93,7 @@ To do so, please [open an issue in the Cross Project Council repository](https:/
 
 ## Getting help
 
-If you have any questions about this policy or need assistance with its implementation, please contact the [OpenJS staff](mailto:operations@openjsf.org).
+If you have any questions about this policy or need assistance with its implementation, please contact the [OpenJS staff](mailto:support@openjsf.org).
 
 [IP Policy]: https://ip-policy.openjsf.org
 [DCO]: https://developercertificate.org

--- a/project-resources/ESP/ECOSYSTEM_SUSTAINABILITY_PROGRAM.md
+++ b/project-resources/ESP/ECOSYSTEM_SUSTAINABILITY_PROGRAM.md
@@ -27,7 +27,7 @@ For a project to participate in the program:
 
 ## How To Participate
 
-Projects that are interested in participating in the program should contact operations@openjsf.org.
+Projects that are interested in participating in the program should contact support@openjsf.org.
 
 ## How To Enroll In Open Collective
 

--- a/project-resources/INFRASTRUCTURE_MENU.md
+++ b/project-resources/INFRASTRUCTURE_MENU.md
@@ -5,7 +5,7 @@ The OpenJS Foundation provides a number of services to support critical infrastr
 ## Billing For Services and Mitigating the Bus Factor
 **For all project services, please add an OpenJS Foundation account at an owner or highest-level of permission access.**  This helps ensure continuity by reducing the bus factor on the project, and ensures you are never locked out. It is also **required** in order for the OpenJS Foundation to pay service fees on behalf of your project. Access to the OpenJS Foundation administrator/owner account will never be shared with others, and will only be granted to operations, IT, and finance staff at the Linux Foundation.
 
-If you don’t know the name of the OpenJS Foundation account for a service, please contact operations@openjsf.org.
+If you don’t know the name of the OpenJS Foundation account for a service, please contact support@openjsf.org.
 
 ## Engaging with a New Third-Party Provider
 
@@ -60,6 +60,6 @@ Projects are welcome to create channels on the OpenJS Foundation Slack (https://
 Projects may request that standing meetings be created and managed via LFX. Community members can request access to manage these meetings.
 
 ## Other services
-We recognize that some projects may have needs not addressed by the above list. For no-cost services, please let us know what you’re using at operations@openjsf.org so that we can add the service to our inventory. For services with a fee, please reach out to operations@openjsf.org to coordinate a proposal and budget request.
+We recognize that some projects may have needs not addressed by the above list. For no-cost services, please let us know what you’re using at support@openjsf.org so that we can add the service to our inventory. For services with a fee, please reach out to support@openjsf.org to coordinate a proposal and budget request.
 
-OpenJS Foundation Member companies can sponsor additional per-project services subject to limitations set by the board. 
+OpenJS Foundation Member companies can sponsor additional per-project services subject to limitations set by the board.

--- a/project-resources/npm-continuity-policy.md
+++ b/project-resources/npm-continuity-policy.md
@@ -31,5 +31,4 @@ To initiate this process, please create an issue in the [CPC repository](https:/
 - Organizations with 1-2 maintainers in the Owner role are the highest priority for this policy and are unlikely to be granted an exception.  
 - Organizations with 3 or more maintainers in the Owner role who have been active in the past [6||12] months will be considered for an exception.
 
-Please contact the OpenJS Foundation ([operations@openjsf.org](mailto:operations@openjsf.org)) for questions or help with this policy.
-
+Please contact the OpenJS Foundation ([support@openjsf.org](mailto:support@openjsf.org)) for questions or help with this policy.

--- a/project-resources/requesting_LFIT_support.md
+++ b/project-resources/requesting_LFIT_support.md
@@ -4,7 +4,7 @@ This guide explains how to request help from the Linux Foundation IT team.
 
 ## Who Is This Document For?
 
-This document is for OpenJS projects that have formally engaged with LF IT to support one or more of their services. If you have questions about a non-LF supported service, please contact operations@openjsf.org.
+This document is for OpenJS projects that have formally engaged with LF IT to support one or more of their services. If you have questions about a non-LF supported service, please contact support@openjsf.org.
 
 ## How To Contact Linux Foundation IT For Support
 
@@ -40,4 +40,4 @@ In the event of an emergency (e.g., a critical system is down or there is a secu
 
 ## Have A Unique Situation?
 
-For urgent, unique, or complex issues that require discussion, please contact operations@openjsf.org.
+For urgent, unique, or complex issues that require discussion, please contact support@openjsf.org.


### PR DESCRIPTION
Per LF guidance the operations@ email address is being moved to internal only. Requests should now go to support@openjsf.org

Requests sent to support@ go to a central support desk staffed by a team, so requests will be seen and routed even if someone is out of office. The team can also handle many of the admin tasks directly. This includes adjusting meetings, mailing lists etc. 

@kj-powell please double check my changes. 

