### PR TITLE
Remove Ecosystem Report from README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ If you are interested in fostering collaboration with the support of the OpenJS 
 | Name                                         |  Repository                        | Authority Delegation   | Description                                                     |
 | -------------------------------------------- |:----------------------------------:| ---------------------- | ----------------------------------------------------------------|
 | AI                                           | [Repository][ai]                   | No                     | Exlore impact of generative AI on JS, open source, and development |
-| Ecosystem Report                             | [Repository][ecosystem-report]     | No                     | JavaScript ecosystem annual end-users poll and report           |
 | Open Visualization (OpenVis)                 | [Repository][openvis]              | No                     | Visualization libraries based on JavaScript and WebGL           |
 | Package Metadata Interop                     | [Repository][pkg-metadata-interop] | No                     | Interoperability of package.json across the JS ecosystem        |
 | Package Vulnerability Management & Reporting | [Repository][pkg-vuln]             | No                     | Package vulnerability management and reporting                  |
@@ -104,7 +103,6 @@ If you are interested in fostering collaboration with the support of the OpenJS 
 | Sustainability                               | [Repository][sustainability]       | No                     | Ensuring long-term sustainability of all OpenJS projects |
 
 [ai]: https://github.com/openjs-foundation/ai-collab-space
-[ecosystem-report]: https://github.com/openjs-foundation/ecosystem-report
 [openvis]: https://github.com/openjs-foundation/openvis-collab-space
 [pkg-metadata-interop]: https://github.com/openjs-foundation/package-metadata-interoperability-collab-space
 [pkg-vuln]: https://github.com/openjs-foundation/pkg-vuln-collab-space


### PR DESCRIPTION
Removed the Ecosystem Report entry from the project overview table in the README.

Fixes #1775 