### PR TITLE
Update CoC Team member information

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ To [appeal][] a decision, please email the [Code of Conduct Team (CoC Team)][CoC
 The Code of Conduct Team (CoC Team) is a foundation-wide team established to manage code of conduct incident reports across the whole foundation (except for [projects who have opted-in][opted-in] to manage reports directly), escalation of reports managed by projects, and appeals to decisions made in response to incidents. The CoC Team is currently composed of:
 
 - Robin Ginn (OpenJSF Executive Director) <rginn@linuxfoundation.org>
-- Kylie Wagar-Dirks (OpenJSF Communications Manager) <kwagar@linuxfoundation.org>
+- Benjamin Sternthal (OpenJSF Program Director - Interim) <bsternthal@linuxfoundation.org>
 - Benjamin Gruenbaum (Primary Community Member) <benjamingr@gmail.com>
 - Chris de Almeida (Primary Community Member) <OpenJS@SoftwareChris.com>
 - Paula Paul (Primary Community Member) <paula@greyshore.com>


### PR DESCRIPTION
Replaced Kylie Wagar-Dirks with Benjamin Sternthal in the CoC Team list. This is an interim change due to Kylie changing roles and moving off the project.